### PR TITLE
more flexible email partial

### DIFF
--- a/users/app/helpers/users_helper.rb
+++ b/users/app/helpers/users_helper.rb
@@ -36,4 +36,11 @@ module UsersHelper
     value || 'not set'
   end
 
+  def wrapped(item, options = {})
+    options[:as] ||= :div
+    content_tag options[:as], :class => dom_class(item), :id => dom_id(item) do
+      yield
+    end
+  end
+
 end

--- a/users/app/models/email.rb
+++ b/users/app/models/email.rb
@@ -22,7 +22,12 @@ module Email
     other.is_a?(Email) ? self.email == other.email : self.email == other
   end
 
+  def to_partial_path
+    "emails/email"
+  end
+
   def to_param
     email
   end
+
 end

--- a/users/app/models/local_email.rb
+++ b/users/app/models/local_email.rb
@@ -27,8 +27,8 @@ class LocalEmail
     strip_domain_if_needed
   end
 
-  def to_partial_path
-    "emails/email"
+  def to_key
+    [username]
   end
 
   protected

--- a/users/app/views/emails/_email.html.haml
+++ b/users/app/views/emails/_email.html.haml
@@ -1,6 +1,6 @@
-%li.pull-right
-  %code= email
-  - if params[:action] == 'edit'
+= wrapped(email, local_assigns) do
+  = email
+  - if local_assigns[:with].try(:include?, :delete)
     = link_to(user_email_alias_path(@user, email), :method => :delete) do
       %i.icon-remove
 .clearfix

--- a/users/app/views/users/_email_aliases.html.haml
+++ b/users/app/views/users/_email_aliases.html.haml
@@ -1,6 +1,6 @@
 .span6
   %ul.unstyled
-    =render @user.email_aliases
+    = render @user.email_aliases, :as => :li, :with => [:delete]
 .clearfix
 = f.simple_fields_for :email_aliases, @email_alias do |e|
   = e.input :username, :placeholder => "alias"

--- a/users/app/views/users/edit.html.haml
+++ b/users/app/views/users/edit.html.haml
@@ -7,7 +7,7 @@
   - content_for :email do
     %legend=t :email_address
     Your email address is
-    = render user.email_address
+    = render user.email_address, :as => :span
     = user_form_with 'email_forward_field', :legend => :forward_email
     = user_form_with 'email_aliases', :legend => :add_email_alias
   = render 'tabs/tabs', :tabs => [:account, :email]


### PR DESCRIPTION
Just an idea how to make the rendering of different versions of the email partial more explicit.
