### PR TITLE
redirect to root_path after canceling account

### DIFF
--- a/users/test/functional/users_controller_test.rb
+++ b/users/test/functional/users_controller_test.rb
@@ -162,7 +162,7 @@ class UsersControllerTest < ActionController::TestCase
     delete :destroy, :id => @current_user.id
 
     assert_response :redirect
-    assert_redirected_to login_path
+    assert_redirected_to root_path
   end
 
   test "non-admin can't destroy user" do


### PR DESCRIPTION
login makes little sense. This change was applied already... just updated the test
