### PR TITLE
Comment out links to show links to email functionality.

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -1,6 +1,6 @@
 %ul.nav.sidenav
   = link_to_navigation t(:overview), user_overview_path(@user), :active => controller?(:overviews)
   = link_to_navigation t(:account_settings), edit_user_path(@user), :active => controller?(:users)
-  = link_to_navigation t(:email_settings), edit_user_email_settings_path(@user), :active => controller?(:email_settings)
+  = #link_to_navigation t(:email_settings), edit_user_email_settings_path(@user), :active => controller?(:email_settings)
   = link_to_navigation t(:support_tickets), auto_tickets_path, :active => controller?(:tickets)
   = link_to_navigation t(:logout), logout_path, :method => :delete

--- a/users/app/views/overviews/show.html.haml
+++ b/users/app/views/overviews/show.html.haml
@@ -17,5 +17,5 @@
 
   %ul.unstyled
     %li= icon('user') + link_to(t(:overview_account), edit_user_path(@user))
-    %li= icon('envelope') + link_to(t(:overview_email), edit_user_email_settings_path(@user))
+    = # %li= icon('envelope') + link_to(t(:overview_email), edit_user_email_settings_path(@user))
     %li= icon('question-sign') + link_to(t(:overview_tickets), user_tickets_path(@user))


### PR DESCRIPTION
Not sure if we want to do this in a more thorough way, but this will hide the links to the email functionality. 
