### PR TITLE
bring back a pgp_key_by_handle view in case this is easier to use

### DIFF
--- a/users/app/models/identity.rb
+++ b/users/app/models/identity.rb
@@ -25,6 +25,15 @@ class Identity < CouchRest::Model::Base
       }
     EOJS
 
+    view :pgp_key_by_handle,
+      map: <<-EOJS
+      function(doc) {
+        if (doc.type != 'Identity') {
+          return;
+        }
+        emit(doc.address.split('@')[0], doc.keys["pgp"]);
+      }
+    EOJS
   end
 
   def self.for(user, attributes = {})


### PR DESCRIPTION
While the destinations might be remote email addresses the incoming address will always be local anyway - so the handle suffices to identify it.
