### PR TITLE
Change JS warning message per https://leap.se/code/issues/3492

### DIFF
--- a/users/app/views/users/_warnings.html.haml
+++ b/users/app/views/users/_warnings.html.haml
@@ -1,5 +1,5 @@
 %noscript
-  %div.alert.alert-error=t :js_required
+  %div.alert.alert-error=t :js_required_html
 #cookie_warning.alert.alert-error{:style => "display:none"}
   =t :cookie_disabled_warning
 :javascript

--- a/users/config/locales/en.yml
+++ b/users/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
   not_authorized_login: "Please log in to perform that action."
   search: "Search"
   cookie_disabled_warning: "You have cookies disabled. You will not be able to login until you enable cookies."
-  js_required: "We are sorry, but this doesn't work without javascript enabled. This is for security reasons."
+  js_required_html: "We are sorry, but this doesn't work without javascript enabled. This is because the authentication system used, <a href='http://srp.stanford.edu/'>SRP</a>, requires javascript."
   enable_account: "Enable the account %{username}"
   enable_description: "This will restore the account to full functionality"
   deactivate_account: "Deactivate the account %{username}"


### PR DESCRIPTION
Key must end in _html so the html doesn't get escaped.
