### PR TITLE
use the same login validations on sessions and users

### DIFF
--- a/users/app/models/login_format_validation.rb
+++ b/users/app/models/login_format_validation.rb
@@ -1,0 +1,19 @@
+module LoginFormatValidation
+  extend ActiveSupport::Concern
+
+  included do
+    # Have multiple regular expression validations so we can get specific error messages:
+    validates :login,
+      :format => { :with => /\A.{2,}\z/,
+        :message => "Login must have at least two characters"}
+    validates :login,
+      :format => { :with => /\A[a-z\d_\.-]+\z/,
+        :message => "Only lowercase letters, digits, . - and _ allowed."}
+    validates :login,
+      :format => { :with => /\A[a-z].*\z/,
+        :message => "Login must begin with a lowercase letter"}
+    validates :login,
+      :format => { :with => /\A.*[a-z\d]\z/,
+        :message => "Login must end with a letter or digit"}
+  end
+end

--- a/users/app/models/session.rb
+++ b/users/app/models/session.rb
@@ -1,12 +1,10 @@
 class Session < SRP::Session
   include ActiveModel::Validations
+  include LoginFormatValidation
 
   attr_accessor :login
 
-  validates :login,
-    :presence => true,
-    :format => { :with => /\A[A-Za-z\d_]+\z/,
-      :message => "Only letters, digits and _ allowed" }
+  validates :login, :presence => true
 
   def initialize(user = nil, aa = nil)
     super(user, aa) if user

--- a/users/app/models/user.rb
+++ b/users/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < CouchRest::Model::Base
+  include LoginFormatValidation
 
   use_database :users
 
@@ -14,20 +15,6 @@ class User < CouchRest::Model::Base
   validates :login,
     :uniqueness => true,
     :if => :serverside?
-
-  # Have multiple regular expression validations so we can get specific error messages:
-  validates :login,
-    :format => { :with => /\A.{2,}\z/,
-      :message => "Login must have at least two characters"}
-  validates :login,
-    :format => { :with => /\A[a-z\d_\.-]+\z/,
-      :message => "Only lowercase letters, digits, . - and _ allowed."}
-  validates :login,
-    :format => { :with => /\A[a-z].*\z/,
-      :message => "Login must begin with a lowercase letter"}
-  validates :login,
-    :format => { :with => /\A.*[a-z\d]\z/,
-      :message => "Login must end with a letter or digit"}
 
   validate :login_is_unique_alias
 

--- a/users/test/integration/browser/account_test.rb
+++ b/users/test/integration/browser/account_test.rb
@@ -28,8 +28,8 @@ class AccountTest < BrowserIntegrationTest
     fill_in 'Password', with: "password"
     inject_malicious_js
     click_on 'Log In'
-    assert !page.has_content?("Welcome")
     assert page.has_content?("Invalid random key")
+    assert page.has_no_content?("Welcome")
   end
 
   def inject_malicious_js


### PR DESCRIPTION
The session ones were outdated so valid usernames could not login if they contained a '.'

Refactored so both models use the same module for this validation to ensure consistency.
This should fix the one integration test that fails occasionally.
