### PR TITLE
Fix couchrest model migrations to work with latest version

### DIFF
--- a/core/leap_web_core.gemspec
+++ b/core/leap_web_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 3.2.11"
 
   s.add_dependency "couchrest", "~> 1.1.3"
-  s.add_dependency "couchrest_model", "~> 2.0.0.beta2"
+  s.add_dependency "couchrest_model", "~> 2.0.0"
   s.add_dependency "couchrest_session_store", "~> 0.2.0"
 
   s.add_dependency "json"

--- a/core/lib/extensions/couchrest.rb
+++ b/core/lib/extensions/couchrest.rb
@@ -42,30 +42,32 @@ module CouchRest
 
     end
 
-    class Migrate
-      def self.load_all_models_with_engines
-        self.load_all_models_without_engines
-        return unless defined?(Rails)
-        Dir[Rails.root + 'app/models/**/*.rb'].each do |path|
-          require path
+    module Utils
+      module Migrate
+        def self.load_all_models_with_engines
+          self.load_all_models_without_engines
+          return unless defined?(Rails)
+          Dir[Rails.root + 'app/models/**/*.rb'].each do |path|
+            require path
+          end
+          Dir[Rails.root + '*/app/models/**/*.rb'].each do |path|
+            require path
+          end
         end
-        Dir[Rails.root + '*/app/models/**/*.rb'].each do |path|
-          require path
+
+        def self.all_models_and_proxies
+          callbacks = migrate_each_model(find_models)
+          callbacks += migrate_each_proxying_model(find_proxying_models)
+          cleanup(callbacks)
         end
+
+
+
+        class << self
+          alias_method_chain :load_all_models, :engines
+        end
+
       end
-
-      def self.all_models_and_proxies
-        callbacks = migrate_each_model(find_models)
-        callbacks += migrate_each_proxying_model(find_proxying_models)
-        cleanup(callbacks)
-      end
-
-
-
-      class << self
-        alias_method_chain :load_all_models, :engines
-      end
-
     end
   end
 


### PR DESCRIPTION
Also we now depend upon couchrest model ~> 2.0.0. The beta2 still has the old naming scheme for CouchRest::Model::Utils::Migrate
