### PR TITLE
blacklist system logins for aliases and logins

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -18,6 +18,11 @@ common: &common
   pagination_size: 30
   auth:
     token_expires_after: 60
+  # handles that will be blocked from being used as logins or email aliases
+  # in addition to the ones in /etc/passwd and http://tools.ietf.org/html/rfc2142
+  handle_blacklist: [certmaster, ssladmin, arin-admin, administrator, www-data, maildrop]
+  # handles that will be allowed despite being in /etc/passwd or rfc2142
+  handle_whitelist: []
 
 development:
   <<: *dev_ca
@@ -43,4 +48,4 @@ production:
   admins: []
   domain: example.net
   payment: []
-# logfile: /path/to/your/logs
+  # logfile: /path/to/your/logs

--- a/users/app/models/local_email.rb
+++ b/users/app/models/local_email.rb
@@ -1,5 +1,10 @@
 class LocalEmail < Email
 
+  BLACKLIST_FROM_RFC2142 = [
+    'postmaster', 'hostmaster', 'domainadmin', 'webmaster', 'www',
+    'abuse', 'noc', 'security', 'usenet', 'news', 'uucp',
+    'ftp', 'sales', 'marketing', 'support', 'info'
+  ]
 
   def self.domain
     APP_CONFIG[:domain]
@@ -10,6 +15,8 @@ class LocalEmail < Email
       :with => /@#{domain}\Z/i,
       :message => "needs to end in @#{domain}"
     }
+
+  validate :handle_allowed
 
   def initialize(s)
     super
@@ -32,4 +39,30 @@ class LocalEmail < Email
     end
   end
 
+  def handle_allowed
+    errors.add(:handle, "is reserved.") if handle_reserved?
+  end
+
+  def handle_reserved?
+    # *ARRAY in a case statement tests if ARRAY includes the handle.
+    case handle
+    when *APP_CONFIG[:handle_blacklist]
+      true
+    when *APP_CONFIG[:handle_whitelist]
+      false
+    when *BLACKLIST_FROM_RFC2142
+      true
+    else
+      handle_in_passwd?
+    end
+  end
+
+  def handle_in_passwd?
+    begin
+      !!Etc.getpwnam(handle)
+    rescue ArgumentError
+      # handle was not found
+      return false
+    end
+  end
 end


### PR DESCRIPTION
We blacklist based on three things:
- blacklist in APP_CONFIG[:handle_blacklist]
- emails in RFC 2142
- usernames in /etc/passwd

The latter two can be allowed by explicitly whitelisting them in APP_CONFIG[:handle_whitelist].

We stick to blocking names that have been configured as both blacklisted and whitelisted - better be save than sorry.
