### PR TITLE
Make download links configurable

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -13,6 +13,23 @@ cert_options: &cert_options
   limited_cert_prefix: "LIMITED"
   unlimited_cert_prefix: "UNLIMITED"
 
+downloads: &downloads
+  client_download_domain: https://downloads.leap.se
+  available_clients:
+    - linux32
+    - linux64
+    - mac
+    - windows
+    - android
+  download_paths:
+    android: /client/android
+    linux:   /client/linux
+    linux32: /client/linux/Bitmask-linux32-latest.tar.bz2
+    linux64: /client/linux/Bitmask-linux64-latest.tar.bz2
+    osx:     /client/osx/Bitmask-OSC-latest.dmg
+    windows: /client/windows
+    other:   /client
+
 common: &common
   force_ssl: false
   pagination_size: 30
@@ -24,7 +41,9 @@ common: &common
   # handles that will be allowed despite being in /etc/passwd or rfc2142
   handle_whitelist: []
 
+
 development:
+  <<: *downloads
   <<: *dev_ca
   <<: *cert_options
   <<: *common
@@ -34,6 +53,7 @@ development:
   payment: []
 
 test:
+  <<: *downloads
   <<: *dev_ca
   <<: *cert_options
   <<: *common
@@ -43,6 +63,7 @@ test:
   payment: [billing]
 
 production:
+  <<: *downloads
   <<: *cert_options
   <<: *common
   admins: []

--- a/core/app/helpers/core_helper.rb
+++ b/core/app/helpers/core_helper.rb
@@ -10,40 +10,4 @@ module CoreHelper
     render 'common/home_page_buttons'
   end
 
-  def available_clients
-    CLIENT_AVAILABILITY
-  end
-
-  def alternative_client_links(os = nil)
-    alternative_clients(os).map do |client|
-      link_to(client.capitalize, client_download_url(client))
-    end
-  end
-
-  def alternative_clients(os = nil)
-    CLIENT_AVAILABILITY - [os]
-  end
-
-  def client_download_url(os = nil)
-    client_download_domain(os) + client_download_path(os)
-  end
-
-  def client_download_domain(os)
-    "https://downloads.leap.se"
-  end
-
-  def client_download_path(os)
-    CLIENT_DOWNLOAD_PATHS[os]  || '/client'
-  end
-
-
-  CLIENT_AVAILABILITY = %w/linux32 linux64 mac windows android/
-  CLIENT_DOWNLOAD_PATHS = {
-    android: '/client/android',
-    linux:   '/client/linux',
-    linux32: '/client/linux/Bitmask-linux32-latest.tar.bz2',
-    linux64: '/client/linux/Bitmask-linux64-latest.tar.bz2',
-    osx:     '/client/osx/Bitmask-OSC-latest.dmg',
-    windows: '/client/windows'
-  }.with_indifferent_access
 end

--- a/core/app/helpers/download_helper.rb
+++ b/core/app/helpers/download_helper.rb
@@ -1,0 +1,33 @@
+module DownloadHelper
+
+  def alternative_client_links(os = nil)
+    alternative_clients(os).map do |client|
+      link_to(client.capitalize, client_download_url(client))
+    end
+  end
+
+  def alternative_clients(os = nil)
+    available_clients - [os]
+  end
+
+  def client_download_url(os = nil)
+    client_download_domain + client_download_path(os)
+  end
+
+  def client_download_path(os)
+    download_paths[os.to_s] || download_paths['other'] || ''
+  end
+
+  def available_clients
+    APP_CONFIG[:available_clients] || []
+  end
+
+  def client_download_domain
+    APP_CONFIG[:client_download_domain] || ''
+  end
+
+  def download_paths
+    APP_CONFIG[:download_paths] || {}
+  end
+
+end


### PR DESCRIPTION
This way we won't have to redeploy once the new links to the windows and the android version are there.

Also this obviously offers more flexibility for providers.
