### PR TITLE
fix download urls for mac, android and windows

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -22,12 +22,12 @@ downloads: &downloads
     - windows
     - android
   download_paths:
-    android: /client/android
+    android: /client/android/Bitmask-Android-latest.apk
     linux:   /client/linux
     linux32: /client/linux/Bitmask-linux32-latest.tar.bz2
     linux64: /client/linux/Bitmask-linux64-latest.tar.bz2
-    osx:     /client/osx/Bitmask-OSC-latest.dmg
-    windows: /client/windows
+    mac:     /client/osx/Bitmask-OSX-latest.dmg
+    windows: /client/windows/Bitmask-win32-latest.zip
     other:   /client
 
 common: &common


### PR DESCRIPTION
They did not point directly to the download.
