### PR TITLE
Return 'provider.json' via a controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ group :test do
   gem 'capybara', require: false
   gem 'launchy' # so save_and_open_page works in integration tests
   gem 'phantomjs-binaries'
+  gem 'minitest'
+  gem 'minitest-stub-const'
 end
 
 # unreleased so far ... but leap_web_certs need it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
     metaclass (0.0.1)
     mime-types (1.25.1)
     mini_portile (0.5.2)
+    minitest (4.7.5)
+    minitest-stub-const (0.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.8.2)
@@ -283,6 +285,8 @@ DEPENDENCIES
   leap_web_core!
   leap_web_help!
   leap_web_users!
+  minitest
+  minitest-stub-const
   mocha (~> 0.13.0)
   phantomjs-binaries
   poltergeist

--- a/app/controllers/static_config_controller.rb
+++ b/app/controllers/static_config_controller.rb
@@ -1,0 +1,24 @@
+#
+# This controller is responsible for returning some static config files, such as /provider.json
+#
+class StaticConfigController < ActionController::Base
+
+  PROVIDER_JSON = File.join(Rails.root, 'config', 'provider', 'provider.json')
+
+  #
+  # return the provider.json, ensuring that the header X-Minimum-Client-Version is sent
+  # regardless if a 200 or 304 (not modified) response is sent.
+  #
+  def provider
+    response.headers["X-Minimum-Client-Version"] = APP_CONFIG[:minimum_client_version].to_s
+    if File.exists?(PROVIDER_JSON)
+      if stale?(:last_modified => File.mtime(PROVIDER_JSON))
+        response.content_type = 'application/json'
+        render :text => File.read(PROVIDER_JSON)
+      end
+    else
+      render :text => 'not found', :status => 404
+    end
+  end
+
+end

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -48,6 +48,8 @@ common: &common
   default_locale: :en
   available_locales:
     - :en
+  minimum_client_version: "0.5"
+
 service_levels: &service_levels
   service_levels:
     0:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ LeapWeb::Application.routes.draw do
   root :to => "home#index"
   get '(:locale)' => 'home#index', :locale => MATCH_LOCALE, :as => 'home'
 
+  get '/provider.json' => 'static_config#provider'
 end

--- a/test/files/provider.json
+++ b/test/files/provider.json
@@ -1,0 +1,3 @@
+{
+  "name": "test provider"
+}

--- a/test/functional/static_config_controller_test.rb
+++ b/test/functional/static_config_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+# use minitest for stubbing, rather than bloated mocha
+require 'minitest/stub_const'
+
+class StaticConfigControllerTest < ActionController::TestCase
+
+  def setup
+  end
+
+  def test_provider_success
+    StaticConfigController.stub_const(:PROVIDER_JSON, file_path('provider.json')) do
+      get :provider, format: :json
+      assert_equal 'application/json', @response.content_type
+      assert_response :success
+    end
+  end
+
+  def test_provider_not_modified
+    StaticConfigController.stub_const(:PROVIDER_JSON, file_path('provider.json')) do
+      request.env["HTTP_IF_MODIFIED_SINCE"] = File.mtime(file_path('provider.json')).rfc2822()
+      get :provider, format: :json
+      assert_response 304
+    end
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,11 @@ Dir["#{File.dirname(__FILE__)}/../*/test/support/**/*.rb"].each { |f| require f 
 
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
+
+  def file_path(name)
+    File.join(Rails.root, 'test', 'files', name)
+  end
+
 end
 
 require 'capybara/poltergeist'


### PR DESCRIPTION
This change is made to be better able to control the response headers (in particular, 'X-Minimum-Client-Version'). It must now be placed in config/provider/provider.json

In the future, I imagine we would switch all the static .json files to be served by this controller.
