### PR TITLE
5382 - prevent crash when destroying tokens

### DIFF
--- a/users/app/models/token.rb
+++ b/users/app/models/token.rb
@@ -40,6 +40,14 @@ class Token < CouchRest::Model::Base
     end
   end
 
+  # Tokens can be cleaned up in different ways.
+  # So let's make sure we don't crash if they disappeared
+  def destroy_with_rescue
+    destroy_without_rescue
+  rescue RestClient::ResourceNotFound
+  end
+  alias_method_chain :destroy, :rescue
+
   def touch
     self.last_seen_at = Time.now
     save

--- a/users/test/unit/token_test.rb
+++ b/users/test/unit/token_test.rb
@@ -78,6 +78,12 @@ class ClientCertificateTest < ActiveSupport::TestCase
   end
 
 
-
+  test "Token.destroy_all_expired does not interfere with expired.authenticate" do
+    expired = FactoryGirl.create :token, last_seen_at: 2.hours.ago
+    with_config auth: {token_expires_after: 60} do
+      Token.destroy_all_expired
+    end
+    assert_nil expired.authenticate
+  end
 
 end


### PR DESCRIPTION
An expired token was removed (probably by automatic cleanup) while processing it. So the webapp crashed due to a couch 404.

We're preventing that by rescueing from a 404 on Token.delete by default.
