### PR TITLE
move User Control Panel heading out of masthead

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,5 +8,5 @@
     %li
       = link_to t(:logout), logout_path, :method => :delete
 - if @user && @show_navigation
-  .user_heading
+  .lead
     = @user.email_address

--- a/app/views/layouts/_masthead.html.haml
+++ b/app/views/layouts/_masthead.html.haml
@@ -2,5 +2,3 @@
   .title
     %span.sitename
       %a{:href => home_path}= APP_CONFIG[:domain]
-    - if @show_navigation
-      = t(:user_control_panel)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,9 @@
       = render 'layouts/masthead'
       #main
         .container-fluid
+          - if @show_navigation
+            .row-fluid
+            %h1= t(:user_control_panel)
           - if logged_in?
             .row-fluid
               .span12


### PR DESCRIPTION
the masthead can only handle content of a limited width.

Alternatively we could make the masthead title wider and add padding on the left so it still aligns nicely with the mask. However the wider we make it the worse it looks on small width displays.

Another option would be to make the masthead contain multiple lines. However vertical aligment to the middle of 1 OR 2 lines of text is a real pain.

So I went with a super simple masthead and the Caption goes below.
