### PR TITLE
open/close toggle and fields in different forms - fixes #5659

### DIFF
--- a/engines/support/app/views/tickets/_edit_form.html.haml
+++ b/engines/support/app/views/tickets/_edit_form.html.haml
@@ -29,6 +29,8 @@
         %b{style: 'padding:10px'}= t(:closed)
         = f.button :loading, t(:open), value: 'open', class: 'btn-mini'
     %span.label.label-clear= t(:created_by_on, :user => created_by, :time => @ticket.created_at.to_s(:short)).html_safe
+= simple_form_for @ticket do |f|
+  = hidden_ticket_fields
   %div= t(:subject)
   = f.text_field :subject, :class => 'large full-width'
   .row-fluid


### PR DESCRIPTION
The bug in question was:
Ticket toggles open/close when pressing enter while focus is on email field
