### PR TITLE
make download button wide enough for helvetica #5039

### DIFF
--- a/app/assets/stylesheets/leap.scss
+++ b/app/assets/stylesheets/leap.scss
@@ -171,7 +171,7 @@ input, textarea {
   }
   .download {
     a.btn {
-      width: 14em;
+      width: 15em;
       font-weight: bold;
       small {
         font-weight: normal;


### PR DESCRIPTION
Download button still looks broken for ivan. I suppose that's because he has other fonts available. 15em width should fix that according to him.
