### PR TITLE
for now completely destroy accounts with their identities

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -35,7 +35,7 @@ class Account
 
   def destroy
     return unless @user
-    Identity.disable_all_for(@user)
+    Identity.destroy_all_for(@user)
     @user.destroy
   end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -76,6 +76,12 @@ class Identity < CouchRest::Model::Base
     end
   end
 
+  def self.destroy_all_for(user)
+    Identity.by_user_id.key(user.id).each do |identity|
+      identity.destroy
+    end
+  end
+
   def self.destroy_all_disabled
     Identity.disabled.each do |identity|
       identity.destroy

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -86,7 +86,7 @@ class UsersControllerTest < ActionController::TestCase
 
     # we destroy the user record and the associated data...
     user.expects(:destroy)
-    Identity.expects(:disable_all_for).with(user)
+    Identity.expects(:destroy_all_for).with(user)
     Ticket.expects(:destroy_all_from).with(user)
 
     login :is_admin? => true
@@ -101,7 +101,7 @@ class UsersControllerTest < ActionController::TestCase
 
     # we destroy the user record and the associated data...
     user.expects(:destroy)
-    Identity.expects(:disable_all_for).with(user)
+    Identity.expects(:destroy_all_for).with(user)
     Ticket.expects(:destroy_all_from).with(user)
 
     login user

--- a/test/integration/browser/account_test.rb
+++ b/test/integration/browser/account_test.rb
@@ -48,12 +48,16 @@ class AccountTest < BrowserIntegrationTest
     assert_invalid_login(page)
   end
 
-  test "handle blocked after account destruction" do
+  # we will block handles of destroyed accounts from
+  # being reused to protect email.
+  # Currently we don't provide email yet and thus clean
+  # them up entirely.
+  test "handle not yet blocked after account destruction" do
     username, password = submit_signup
     click_on I18n.t('account_settings')
     click_on I18n.t('destroy_my_account')
     submit_signup(username)
-    assert page.has_content?('has already been taken')
+    assert page.has_content?("Welcome #{username}")
   end
 
   test "default user actions" do

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -17,8 +17,10 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   test "create and remove a user account" do
-    # We keep an identity that will block the handle from being reused.
-    assert_difference "Identity.count" do
+    # Currently we clean up the account entirely.
+    # Later we will keep an identity that will block
+    # the handle from being reused.
+    assert_no_difference "Identity.count" do
       assert_no_difference "User.count" do
         user = Account.create(FactoryGirl.attributes_for(:user))
         user.account.destroy


### PR DESCRIPTION
We're not providing email as a service yet. So getting someone elses account
after they left the provider is not a big deal yet.

We want two options to pick from in the medium term
