### PR TITLE
if identity fails to be created, destroy the user. 

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -18,9 +18,18 @@ class Account
   def self.create(attrs)
     @user = User.create(attrs)
     if @user.persisted?
-      identity = @user.identity
-      identity.user_id = @user.id
-      identity.save
+      @identity = @user.identity
+      @identity.user_id = @user.id
+      @identity.save
+      @identity.errors.each do |attr, msg|
+        @user.errors.add(attr, msg)
+      end
+    end
+  rescue StandardError => ex
+    @user.errors.add(:base, ex.to_s)
+  ensure
+    if @user.persisted? && (@identity.nil? || !@identity.persisted?)
+      @user.destroy
     end
     return @user
   end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -163,4 +163,5 @@ class Identity < CouchRest::Model::Base
     end
   end
 
+  ActiveSupport.run_load_hooks(:identity, self)
 end


### PR DESCRIPTION
also, pass through identity errors to user and add identity class hook.

these changes are needed to better support custom hooks that remotely verify if username is available.

there are a lot of errors that can happen with a remote service, and we want to make sure we catch all possible errors and report something to the user.
