### PR TITLE
create client certificates with generous not_before (fixes #5884)

### DIFF
--- a/app/models/client_certificate.rb
+++ b/app/models/client_certificate.rb
@@ -24,7 +24,7 @@ class ClientCertificate
     cert.subject.common_name = common_name(options[:prefix])
 
     # set expiration
-    cert.not_before = yesterday
+    cert.not_before = last_month
     cert.not_after = months_from_yesterday(APP_CONFIG[:client_cert_lifespan])
 
     # generate key
@@ -108,6 +108,11 @@ class ClientCertificate
 
   def yesterday
     t = Time.now - 24*60*60
+    Time.utc t.year, t.month, t.day
+  end
+
+  def last_month
+    t = Time.now - 24*60*60*30
     Time.utc t.year, t.month, t.day
   end
 


### PR DESCRIPTION
i don't see any reason to not have a generous not_before value, and making it valid far back in the past allows bitmask clients to work even if the device has a bad date set.
