### PR TITLE
Bump therubyracer to 0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :production do
   gem "uglifier", "~> 1.2.7"    # javascript compression https://github.com/lautis/uglifier
                                 # this must not be included in development mode, or js
                                 # will get included twice.
-  gem 'therubyracer', "~> 0.10.2", :platforms => :ruby
+  gem 'therubyracer', "~> 0.12.2", :platforms => :ruby
   #   ^^ See https://github.com/sstephenson/execjs#readme
   #      for list of supported runtimes.
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       railties (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.3.10.4)
+    libv8 (3.16.14.11)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -203,6 +203,7 @@ GEM
     rdiscount (2.1.7.1)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (2.0.0)
     rest-client (1.6.8)
       mime-types (~> 1.16)
       rdoc (>= 2.4.2)
@@ -226,8 +227,9 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     sys-uname (0.9.0)
       ffi (>= 1.0.0)
-    therubyracer (0.10.2)
-      libv8 (~> 3.3.10)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
@@ -291,7 +293,10 @@ DEPENDENCIES
   ruby-srp (~> 0.2.1)
   sass-rails (~> 3.2.5)
   simple_form
-  therubyracer (~> 0.10.2)
+  therubyracer (~> 0.12.2)
   thin
   uglifier (~> 1.2.7)
   valid_email
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
therubracer 0.10.2 has problems with compiling libv8 on OSX[1].  Updating the dependency resolves the issue.

[1]: https://stackoverflow.com/questions/19630154/gem-install-therubyracer-v-0-10-2-on-osx-mavericks-not-installing