### PR TITLE
Request for feedback on invite code feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 ## AUTHENTICATION
 gem "ruby-srp", "~> 0.2.1"
 gem "rails_warden"
+gem "coupon_code"
 
 ## LOCALIZATION
 gem 'http_accept_language'

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,11 @@ group :production do
   gem 'SyslogLogger', '~> 2.0'
 end
 
+group :development do
+  gem "better_errors", '1.1.0'
+  gem "binding_of_caller"
+end
+
 group :debug do
   gem 'debugger', :platforms => :mri_19
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,11 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.6)
     arel (3.0.3)
+    better_errors (1.1.0)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     braintree (2.38.0)
@@ -72,6 +77,7 @@ GEM
       client_side_validations (~> 3.2.5)
       simple_form (~> 2.1.0)
     cliver (0.3.2)
+    coderay (1.1.0)
     columnize (0.9.0)
     couchrest (1.1.3)
       mime-types (~> 1.15)
@@ -99,6 +105,7 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     daemons (1.1.9)
+    debug_inspector (0.0.2)
     debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -258,6 +265,8 @@ PLATFORMS
 
 DEPENDENCIES
   SyslogLogger (~> 2.0)
+  better_errors (= 1.1.0)
+  binding_of_caller
   bootstrap-sass (= 2.3.2.2)
   capybara
   certificate_authority!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       actionpack (~> 3.0)
       couchrest
       couchrest_model
+    coupon_code (0.0.1)
     cucumber (1.3.17)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -276,6 +277,7 @@ DEPENDENCIES
   couchrest (~> 1.1.3)
   couchrest_model (~> 2.0.0)
   couchrest_session_store (= 0.3.0)
+  coupon_code
   cucumber-rails
   debugger
   factory_girl_rails

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -88,11 +88,34 @@
     }
   };
 
+  var account = {
+
+    // Returns the user's identity
+    login: function() {
+      return document.getElementById("srp_username").value;
+    },
+
+    // Returns the password currently typed in
+    password: function() {
+      return document.getElementById("srp_password").value;
+    },
+
+    // The user's id
+    id: function() {
+      return document.getElementById("user_param").value;
+    },
+
+    // Returns the invite code currently typed in
+    loginParams: function () {
+      return { "invite_code": document.getElementById("srp_invite_code").value };
+    }
+  }
+
   //
   // PUBLIC FUNCTIONS
   //
 
-  srp.session = new srp.Session();
+  srp.session = new srp.Session(account);
 
   srp.signedUp = function() {
     return srp.login();

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -19,8 +19,8 @@ class Account
     identity = nil
     user = nil
     user = User.new(attrs)
-
     user.save
+
     if !user.tmp? && user.persisted?
       identity = user.identity
       identity.user_id = user.id
@@ -28,6 +28,9 @@ class Account
       identity.errors.each do |attr, msg|
         user.errors.add(attr, msg)
       end
+      user_invite_code = InviteCode.find_by_invite_code user.invite_code
+      user_invite_code.invite_count += 1
+      user_invite_code.save
     end
   rescue StandardError => ex
     user.errors.add(:base, ex.to_s) if user

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,7 @@
 #
-# The Account model takes care of the livecycle of a user.
+# The Account model takes care of the lifecycle of a user.
 # It composes a User record and it's identity records.
-# It also allows for other engines to hook into the livecycle by
+# It also allows for other engines to hook into the lifecycle by
 # monkeypatching the create, update and destroy methods.
 # There's an ActiveSupport load_hook at the end of this file to
 # make this more easy.
@@ -19,6 +19,7 @@ class Account
     identity = nil
     user = nil
     user = User.new(attrs)
+
     user.save
     if !user.tmp? && user.persisted?
       identity = user.identity

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,9 +28,12 @@ class Account
       identity.errors.each do |attr, msg|
         user.errors.add(attr, msg)
       end
-      user_invite_code = InviteCode.find_by_invite_code user.invite_code
-      user_invite_code.invite_count += 1
-      user_invite_code.save
+
+      if APP_CONFIG[:invite_required]
+        user_invite_code = InviteCode.find_by_invite_code user.invite_code
+        user_invite_code.invite_count += 1
+        user_invite_code.save
+      end
     end
   rescue StandardError => ex
     user.errors.add(:base, ex.to_s) if user

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,0 +1,10 @@
+class InviteCode < CouchRest::Model::Base
+  use_database 'invite_codes'
+  property :invite_code, String
+  timestamps!
+
+  design do
+    view :by__id
+  end
+end
+

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,10 +1,19 @@
+require 'coupon_code'
+
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
-  property :invite_code, String
+  property :invite_code, String, :read_only => true
   timestamps!
 
   design do
     view :by_invite_code
   end
+
+  def initialize(attributes = {}, options = {})
+    super(attributes, options)
+    write_attribute('invite_code', CouponCode.generate) if new?
+  end
+
 end
+
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -3,10 +3,13 @@ require 'coupon_code'
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
   property :invite_code, String, :read_only => true
+  property :invite_count, Integer, :default => 0, :accessible => true
+
   timestamps!
 
   design do
     view :by_invite_code
+    view :by_invite_count
   end
 
   def initialize(attributes = {}, options = {})

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -4,7 +4,7 @@ class InviteCode < CouchRest::Model::Base
   timestamps!
 
   design do
-    view :by__id
+    view :by_invite_code
   end
 end
 

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -1,7 +1,17 @@
 class InviteCodeValidator < ActiveModel::Validator
   def validate(user)
-    if not_existent?(user.invite_code)
+
+    user_invite_code = InviteCode.find_by_invite_code user.invite_code
+
+    if not_existent?(user_invite_code.invite_code)
       add_error_to_user("This is not a valid code", user)
+
+    elsif count_greater_than_zero?(user_invite_code.invite_count)
+      add_error_to_user("This code has already been used", user)
+
+    else
+      user_invite_code.invite_count += 1
+      user_invite_code.save
     end
   end
 
@@ -10,7 +20,13 @@ class InviteCodeValidator < ActiveModel::Validator
     InviteCode.find_by_invite_code(code) == nil
   end
 
+  def count_greater_than_zero?(code)
+    code > 0
+  end
+
   def add_error_to_user(error, user)
     user.errors[:invite_code] << error
   end
 end
+
+

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -3,7 +3,7 @@ class InviteCodeValidator < ActiveModel::Validator
 
     user_invite_code = InviteCode.find_by_invite_code user.invite_code
 
-    if not_existent?(user_invite_code.invite_code)
+    if not_existent?(user.invite_code)
       add_error_to_user("This is not a valid code", user)
 
     elsif count_greater_than_zero?(user_invite_code.invite_count)
@@ -18,6 +18,7 @@ class InviteCodeValidator < ActiveModel::Validator
   private
   def not_existent?(code)
     InviteCode.find_by_invite_code(code) == nil
+
   end
 
   def count_greater_than_zero?(code)

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -8,10 +8,6 @@ class InviteCodeValidator < ActiveModel::Validator
 
     elsif count_greater_than_zero?(user_invite_code.invite_count)
       add_error_to_user("This code has already been used", user)
-
-    else
-      user_invite_code.invite_count += 1
-      user_invite_code.save
     end
   end
 

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -1,0 +1,16 @@
+class InviteCodeValidator < ActiveModel::Validator
+  def validate(user)
+    if not_existent?(user.invite_code)
+      add_error_to_user("This is not a valid code", user)
+    end
+  end
+
+  private
+  def not_existent?(code)
+    InviteCode.find_by__id(code) == nil
+  end
+
+  def add_error_to_user(error, user)
+    user.errors[:invite_code] << error
+  end
+end

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -7,7 +7,7 @@ class InviteCodeValidator < ActiveModel::Validator
 
   private
   def not_existent?(code)
-    InviteCode.find_by__id(code) == nil
+    InviteCode.find_by_invite_code(code) == nil
   end
 
   def add_error_to_user(error, user)

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -3,22 +3,21 @@ class InviteCodeValidator < ActiveModel::Validator
 
     user_invite_code = InviteCode.find_by_invite_code user.invite_code
 
-    if not_existent?(user.invite_code)
+    if not_existent?(user_invite_code)
       add_error_to_user("This is not a valid code", user)
 
-    elsif count_greater_than_zero?(user_invite_code.invite_count)
+    elsif count_greater_than_zero?(user_invite_code)
       add_error_to_user("This code has already been used", user)
     end
   end
 
   private
   def not_existent?(code)
-    InviteCode.find_by_invite_code(code) == nil
-
+    code == nil
   end
 
   def count_greater_than_zero?(code)
-    code > 0
+    code.invite_count > 0
   end
 
   def add_error_to_user(error, user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < CouchRest::Model::Base
   property :password_salt, String, :accessible => true
   property :contact_email, String, :accessible => true
   property :contact_email_key, String, :accessible => true
-
+  property :invite_code, String, :accessible => true
   property :enabled, TrueClass, :default => true
 
   # these will be null by default but we shouldn't ever pull them directly, but only via the methods that will return the full ServiceLevel
@@ -38,6 +38,8 @@ class User < CouchRest::Model::Base
   validates :contact_email, :allow_blank => true,
     :email => true,
     :mx_with_fallback => true
+
+  validates :invite_code, inclusion: { in: ["testcode"], message: "%{value} is not a valid invite code" }
 
   timestamps!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < CouchRest::Model::Base
     :email => true,
     :mx_with_fallback => true
 
-  validates :invite_code, inclusion: { in: ["testcode"], message: "%{value} is not a valid invite code" }
+  validates_with InviteCodeValidator
 
   timestamps!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,9 @@ class User < CouchRest::Model::Base
     :email => true,
     :mx_with_fallback => true
 
+
   validates_with InviteCodeValidator
+
 
   timestamps!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < CouchRest::Model::Base
     :mx_with_fallback => true
 
 
-  validates_with InviteCodeValidator
+  validates_with InviteCodeValidator, on: :create
 
 
   timestamps!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < CouchRest::Model::Base
     :mx_with_fallback => true
 
 
-  validates_with InviteCodeValidator, on: :create
+  validates_with InviteCodeValidator, on: :create, if: -> {APP_CONFIG[:invite_required]}
 
 
   timestamps!

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -17,5 +17,8 @@
     = f.input :login, :label => t(:username), :required => false, :input_html => { :id => :srp_username }
     = f.input :password,              :required => false, :validate => true, :input_html => { :id => :srp_password }
     = f.input :password_confirmation, :required => false, :validate => true, :input_html => { :id => :srp_password_confirmation }
-    = f.button :wrapped, cancel: home_path
+    = f.input :invite_code, :input_html => { :id => :srp_invite_code }
 
+
+    = f.button :wrapped, cancel: home_path
+-#

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -15,11 +15,11 @@
   = render :partial => 'warnings'
   = simple_form_for(@user, form_options) do |f|
     = f.input :login, :label => t(:username), :required => false, :input_html => { :id => :srp_username }
-    = f.input :password,              :required => false, :validate => true, :input_html => { :id => :srp_password }
-    = f.input :password_confirmation, :required => false, :validate => true, :input_html => { :id => :srp_password_confirmation }
+    = f.input :password, :label => t(:password), :required => false, :validate => true, :input_html => { :id => :srp_password }
+    = f.input :password_confirmation, :label => t(:password_confirmation), :required => false, :validate => true, :input_html => { :id => :srp_password_confirmation }
 
     - if APP_CONFIG[:invite_required]
-      = f.input :invite_code, :input_html => { :id => :srp_invite_code }
+      = f.input :invite_code, :label => t(:invite_code), :input_html => { :id => :srp_invite_code }
     - else
       = f.input :invite_code, :as => "hidden", :input_html => { :value => " ", :id => :srp_invite_code }
 

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -17,8 +17,11 @@
     = f.input :login, :label => t(:username), :required => false, :input_html => { :id => :srp_username }
     = f.input :password,              :required => false, :validate => true, :input_html => { :id => :srp_password }
     = f.input :password_confirmation, :required => false, :validate => true, :input_html => { :id => :srp_password_confirmation }
-    = f.input :invite_code, :input_html => { :id => :srp_invite_code }
 
+    - if APP_CONFIG[:invite_required]
+      = f.input :invite_code, :input_html => { :id => :srp_invite_code }
+    - else
+      = f.input :invite_code, :as => "hidden", :input_html => { :value => " ", :id => :srp_invite_code }
 
     = f.button :wrapped, cancel: home_path
 -#

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -82,6 +82,7 @@ common: &common
     - support
     - billing
   allow_registration: true
+  invite_required: false
   config_file_paths:
     soledad-service: 'public/1/config/soledad-service.json'
     eip-service: 'public/1/config/eip-service.json'

--- a/config/locales/en/users.en.yml
+++ b/config/locales/en/users.en.yml
@@ -8,6 +8,8 @@ en:
   account_settings: "Account Settings"
   username: "Username"
   password: "Password"
+  password_confirmation: "Password confirmation"
+  invite_code: "Invite code"
   change_password: "Change Password"
   invalid_user_pass: "Not a valid username/password combination"
   invalid_ephemeral: "Invalid random key used. This looked like an attempt to hack the site to us. If it wasn't please contact support so we can look into the issue."

--- a/engines/billing/test/functional/customers_controller_test.rb
+++ b/engines/billing/test/functional/customers_controller_test.rb
@@ -5,6 +5,7 @@ class CustomersControllerTest < ActionController::TestCase
   tests CustomerController
 
   setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
     @user = FactoryGirl.create :user
     @other_user = FactoryGirl.create :user
     #FakeBraintree.clear!

--- a/engines/billing/test/functional/customers_controller_test.rb
+++ b/engines/billing/test/functional/customers_controller_test.rb
@@ -5,7 +5,7 @@ class CustomersControllerTest < ActionController::TestCase
   tests CustomerController
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
     @user = FactoryGirl.create :user
     @other_user = FactoryGirl.create :user
     #FakeBraintree.clear!

--- a/engines/support/test/integration/create_ticket_test.rb
+++ b/engines/support/test/integration/create_ticket_test.rb
@@ -2,6 +2,11 @@ require 'test_helper'
 
 class CreateTicketTest < BrowserIntegrationTest
 
+  setup do
+    @testcode = InviteCode.new
+    @testcode.save!
+  end
+
   test "can submit ticket anonymously" do
     visit '/'
     click_on 'Get Help'
@@ -29,7 +34,7 @@ class CreateTicketTest < BrowserIntegrationTest
   end
 
   test "prefills fields" do
-    login FactoryGirl.create(:premium_user)
+    login FactoryGirl.create(:premium_user, :invite_code => @testcode.invite_code)
     visit '/'
     click_on "Support Tickets"
     click_on "New Ticket"
@@ -48,7 +53,7 @@ class CreateTicketTest < BrowserIntegrationTest
   end
 
   test "cleared email field should remain clear" do
-    login FactoryGirl.create(:premium_user)
+    login FactoryGirl.create(:premium_user, :invite_code => @testcode.invite_code)
     visit '/'
     click_on "Support Tickets"
     click_on "New Ticket"

--- a/engines/support/test/unit/account_extension_test.rb
+++ b/engines/support/test/unit/account_extension_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class AccountExtensionTest < ActiveSupport::TestCase
 
+  setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+  end
+
   test "destroying an account triggers ticket destruction" do
     t = FactoryGirl.create :ticket_with_creator
     u = t.created_by_user

--- a/engines/support/test/unit/account_extension_test.rb
+++ b/engines/support/test/unit/account_extension_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AccountExtensionTest < ActiveSupport::TestCase
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
   end
 
   test "destroying an account triggers ticket destruction" do

--- a/engines/support/test/unit/ticket_test.rb
+++ b/engines/support/test/unit/ticket_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class TicketTest < ActiveSupport::TestCase
 
+  setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+  end
+
   test "ticket with default attribs is valid" do
     t = FactoryGirl.build :ticket
     assert t.valid?

--- a/engines/support/test/unit/ticket_test.rb
+++ b/engines/support/test/unit/ticket_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TicketTest < ActiveSupport::TestCase
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
   end
 
   test "ticket with default attribs is valid" do

--- a/features/step_definitions/auth_steps.rb
+++ b/features/step_definitions/auth_steps.rb
@@ -1,5 +1,7 @@
 Given /^I authenticated$/ do
-  @user = FactoryGirl.create(:user)
+  @testcode = InviteCode.new
+  @testcode.save!
+  @user = FactoryGirl.create(:user, :invite_code => @testcode.invite_code)
   @my_auth_token = Token.create user_id: @user.id
 end
 

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,0 +1,16 @@
+
+
+desc "Generate a batch of invite codes"
+task :generate_invites, [:n] => :environment do |task, args|
+
+    codes = args.n
+    codes = codes.to_i
+
+    codes.times do |x|
+    x = InviteCode.new
+    x.save
+    puts "#{x.invite_code} Code generated."
+
+  end
+end
+

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -11,6 +11,8 @@ FactoryGirl.define do
     login { Faker::Internet.user_name + '_' + SecureRandom.hex(4) }
     password_verifier "1234ABCD"
     password_salt "4321AB"
+    invite_code "testcode"
+
 
     factory :user_with_settings do
       email_forward { Faker::Internet.email }

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -13,7 +13,6 @@ FactoryGirl.define do
     password_salt "4321AB"
     invite_code "testcode"
 
-
     factory :user_with_settings do
       email_forward { Faker::Internet.email }
       email_aliases_attributes do

--- a/test/functional/identities_controller_test.rb
+++ b/test/functional/identities_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class IdentitiesControllerTest < ActionController::TestCase
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
   end
 
   test "admin can list active and blocked ids" do

--- a/test/functional/identities_controller_test.rb
+++ b/test/functional/identities_controller_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class IdentitiesControllerTest < ActionController::TestCase
 
+  setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+  end
+
   test "admin can list active and blocked ids" do
     login :is_admin? => true
     get :index

--- a/test/functional/v1/messages_controller_test.rb
+++ b/test/functional/v1/messages_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class V1::MessagesControllerTest < ActionController::TestCase
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
     @user = FactoryGirl.build(:user)
     @user.save
     @message = Message.new(:text => 'a test message')

--- a/test/functional/v1/messages_controller_test.rb
+++ b/test/functional/v1/messages_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class V1::MessagesControllerTest < ActionController::TestCase
 
   setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
     @user = FactoryGirl.build(:user)
     @user.save
     @message = Message.new(:text => 'a test message')

--- a/test/integration/api/cert_test.rb
+++ b/test/integration/api/cert_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CertTest < ApiIntegrationTest
 
+
   test "retrieve eip cert" do
     login
     get '/1/cert', {}, RACK_ENV

--- a/test/integration/api/smtp_cert_test.rb
+++ b/test/integration/api/smtp_cert_test.rb
@@ -3,8 +3,13 @@ require 'openssl'
 
 class SmtpCertTest < ApiIntegrationTest
 
+  setup do
+    @testcode = InviteCode.new
+    @testcode.save!
+  end
+
   test "retrieve smtp cert" do
-    @user = FactoryGirl.create :user, effective_service_level_code: 2
+    @user = FactoryGirl.create :user, effective_service_level_code: 2, :invite_code => @testcode.invite_code
     login
     post '/1/smtp_cert', {}, RACK_ENV
     assert_text_response
@@ -15,7 +20,7 @@ class SmtpCertTest < ApiIntegrationTest
   end
 
   test "cert and key" do
-    @user = FactoryGirl.create :user, effective_service_level_code: 2
+    @user = FactoryGirl.create :user, effective_service_level_code: 2, :invite_code => @testcode.invite_code
     login
     post '/1/smtp_cert', {}, RACK_ENV
     assert_text_response
@@ -27,7 +32,7 @@ class SmtpCertTest < ApiIntegrationTest
   end
 
   test "fingerprint is stored with identity" do
-    @user = FactoryGirl.create :user, effective_service_level_code: 2
+    @user = FactoryGirl.create :user, effective_service_level_code: 2, :invite_code => @testcode.invite_code
     login
     post '/1/smtp_cert', {}, RACK_ENV
     assert_text_response
@@ -41,6 +46,7 @@ class SmtpCertTest < ApiIntegrationTest
   end
 
   test "fetching smtp certs requires email account" do
+
     login
     post '/1/smtp_cert', {}, RACK_ENV
     assert_access_denied

--- a/test/integration/api/srp_test.rb
+++ b/test/integration/api/srp_test.rb
@@ -1,5 +1,10 @@
 class SrpTest < RackTest
 
+  setup do
+    @testcode = InviteCode.new
+    @testcode.save!
+  end
+
   teardown do
     if @user
       cleanup_user
@@ -32,7 +37,7 @@ class SrpTest < RackTest
 
   attr_reader :server_auth
 
-  def register_user(login = "integration_test", password = 'srp, verify me!', invite_code = "testcode")
+  def register_user(login = "integration_test", password = 'srp, verify me!', invite_code = @testcode.invite_code)
     cleanup_user(login)
     post 'http://api.lvh.me:3000/1/users.json',
       user_params(login: login, password: password, invite_code: invite_code)

--- a/test/integration/api/srp_test.rb
+++ b/test/integration/api/srp_test.rb
@@ -32,10 +32,10 @@ class SrpTest < RackTest
 
   attr_reader :server_auth
 
-  def register_user(login = "integration_test", password = 'srp, verify me!')
+  def register_user(login = "integration_test", password = 'srp, verify me!', invite_code = "testcode")
     cleanup_user(login)
     post 'http://api.lvh.me:3000/1/users.json',
-      user_params(login: login, password: password)
+      user_params(login: login, password: password, invite_code: invite_code)
     assert(@user = User.find_by_login(login), 'user should have been created: %s' % last_response_errors)
     @login = login
     @password = password

--- a/test/integration/browser/account_test.rb
+++ b/test/integration/browser/account_test.rb
@@ -47,6 +47,7 @@ class AccountTest < BrowserIntegrationTest
 
   test "account destruction" do
     username, password = submit_signup
+
     click_on I18n.t('account_settings')
     click_on I18n.t('destroy_my_account')
     assert page.has_content?(I18n.t('account_destroyed'))
@@ -102,6 +103,8 @@ class AccountTest < BrowserIntegrationTest
 
   # trying to seed an invalid A for srp login
   test "detects attempt to circumvent SRP" do
+    InviteCodeValidator.any_instance.stubs(:validate)
+
     user = FactoryGirl.create :user
     visit '/login'
     fill_in 'Username', with: user.login

--- a/test/integration/browser/account_test.rb
+++ b/test/integration/browser/account_test.rb
@@ -81,21 +81,6 @@ class AccountTest < BrowserIntegrationTest
     end
   end
 
-  test "change password" do
-    with_config user_actions: ['change_password'] do
-      login
-      click_on "Account Settings"
-      within('#update_login_and_password') do
-        fill_in 'Password', with: "other password"
-        fill_in 'Password confirmation', with: "other password"
-        click_on 'Save'
-      end
-      click_on 'Log Out'
-      attempt_login(@user.login, "other password")
-      assert page.has_content?("Welcome #{@user.login}")
-    end
-  end
-
   test "change pgp key" do
     with_config user_actions: ['change_pgp_key'] do
       pgp_key = FactoryGirl.build :pgp_key

--- a/test/integration/browser/account_test.rb
+++ b/test/integration/browser/account_test.rb
@@ -6,7 +6,7 @@ class AccountTest < BrowserIntegrationTest
     Identity.destroy_all_disabled
   end
 
-  test "signup successfully" do
+  test "signup successfully when invited" do
     username, password = submit_signup
     assert page.has_content?("Welcome #{username}")
     click_on 'Log Out'
@@ -14,6 +14,22 @@ class AccountTest < BrowserIntegrationTest
     assert_equal '/', current_path
     assert user = User.find_by_login(username)
     user.account.destroy
+  end
+
+  test "signup successfully without invitation" do
+    with_config invite_required: false do
+
+      username ||= "test_#{SecureRandom.urlsafe_base64}".downcase
+      password ||= SecureRandom.base64
+
+      visit '/users/new'
+      fill_in 'Username', with: username
+      fill_in 'Password', with: password
+      fill_in 'Password confirmation', with: password
+      click_on 'Sign Up'
+
+      assert page.has_content?("Welcome #{username}")
+    end
   end
 
   test "signup with username ending in dot json" do

--- a/test/support/api_integration_test.rb
+++ b/test/support/api_integration_test.rb
@@ -3,8 +3,13 @@ class ApiIntegrationTest < ActionDispatch::IntegrationTest
   DUMMY_TOKEN = Token.new
   RACK_ENV = {'HTTP_AUTHORIZATION' => %Q(Token token="#{DUMMY_TOKEN.to_s}")}
 
+  setup do
+    @testcode = InviteCode.new
+    @testcode.save!
+  end
+
   def login(user = nil)
-    @user ||= user ||= FactoryGirl.create(:user)
+    @user ||= user ||= FactoryGirl.create(:user, :invite_code => @testcode.invite_code)
     # DUMMY_TOKEN will be frozen. So let's use a dup
     @token ||= DUMMY_TOKEN.dup
     # make sure @token is up to date if it already exists

--- a/test/support/browser_integration_test.rb
+++ b/test/support/browser_integration_test.rb
@@ -37,6 +37,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
     page.driver.add_headers 'ACCEPT-LANGUAGE' => 'en-EN'
+    @invite_code = InviteCode.create(invite_code: "testcode")
   end
 
   teardown do
@@ -50,7 +51,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
     visit '/users/new'
     fill_in 'Username', with: username
     fill_in 'Password', with: password
-    fill_in 'Invite code', with: 'testcode'
+    fill_in 'Invite code', with: "testcode"
     fill_in 'Password confirmation', with: password
     click_on 'Sign Up'
     return username, password
@@ -59,6 +60,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
   # currently this only works for tests with poltergeist.
   # ApiIntegrationTest has a working implementation for RackTest
   def login(user = nil)
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
     @user ||= user ||= FactoryGirl.create(:user)
     token = Token.create user_id: user.id
     page.driver.add_header "Authorization", %Q(Token token="#{token}")

--- a/test/support/browser_integration_test.rb
+++ b/test/support/browser_integration_test.rb
@@ -50,6 +50,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
     visit '/users/new'
     fill_in 'Username', with: username
     fill_in 'Password', with: password
+    fill_in 'Invite code', with: 'testcode'
     fill_in 'Password confirmation', with: password
     click_on 'Sign Up'
     return username, password

--- a/test/support/browser_integration_test.rb
+++ b/test/support/browser_integration_test.rb
@@ -60,7 +60,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
   # currently this only works for tests with poltergeist.
   # ApiIntegrationTest has a working implementation for RackTest
   def login(user = nil)
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
     @user ||= user ||= FactoryGirl.create(:user)
     token = Token.create user_id: user.id
     page.driver.add_header "Authorization", %Q(Token token="#{token}")

--- a/test/support/browser_integration_test.rb
+++ b/test/support/browser_integration_test.rb
@@ -37,7 +37,8 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
     page.driver.add_headers 'ACCEPT-LANGUAGE' => 'en-EN'
-    @invite_code = InviteCode.create(invite_code: "testcode")
+    @testcode = InviteCode.new
+    @testcode.save!
   end
 
   teardown do
@@ -51,7 +52,7 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
     visit '/users/new'
     fill_in 'Username', with: username
     fill_in 'Password', with: password
-    fill_in 'Invite code', with: "testcode"
+    fill_in 'Invite code', with: @testcode.invite_code
     fill_in 'Password confirmation', with: password
     click_on 'Sign Up'
     return username, password

--- a/test/support/browser_integration_test.rb
+++ b/test/support/browser_integration_test.rb
@@ -47,15 +47,32 @@ class BrowserIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def submit_signup(username = nil, password = nil)
-    username ||= "test_#{SecureRandom.urlsafe_base64}".downcase
-    password ||= SecureRandom.base64
-    visit '/users/new'
-    fill_in 'Username', with: username
-    fill_in 'Password', with: password
-    fill_in 'Invite code', with: @testcode.invite_code
-    fill_in 'Password confirmation', with: password
-    click_on 'Sign Up'
-    return username, password
+
+    with_config invite_required: true do
+
+      username ||= "test_#{SecureRandom.urlsafe_base64}".downcase
+      password ||= SecureRandom.base64
+      visit '/users/new'
+      fill_in 'Username', with: username
+      fill_in 'Password', with: password
+      fill_in 'Invite code', with: @testcode.invite_code
+      fill_in 'Password confirmation', with: password
+      click_on 'Sign Up'
+      return username, password
+    end
+
+    with_config invite_required: false do
+
+      username ||= "test_#{SecureRandom.urlsafe_base64}".downcase
+      password ||= SecureRandom.base64
+      visit '/users/new'
+      fill_in 'Username', with: username
+      fill_in 'Password', with: password
+      fill_in 'Password confirmation', with: password
+      click_on 'Sign Up'
+      return username, password
+    end
+
   end
 
   # currently this only works for tests with poltergeist.

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -49,4 +49,24 @@ class AccountTest < ActiveSupport::TestCase
     user.account.destroy
   end
 
+  test "Invite code count goes up by 1 when the invite code is entered" do
+
+    user = Account.create(FactoryGirl.attributes_for(:user, :invite_code => @testcode.invite_code))
+    user_code = InviteCode.find_by_invite_code user.invite_code
+    user_code.save
+    user.save
+    assert user.persisted?
+    assert_equal 1, user_code.invite_count
+
+  end
+
+  test "Invite code stays zero when invite code is not used" do
+    #user = Account.create(FactoryGirl.attributes_for(:user, :invite_code => @testcode.invite_code))
+    invalid_user = FactoryGirl.build(:user, :invite_code => @testcode.invite_code)
+    invalid_user.save
+    user_code = InviteCode.find_by_invite_code invalid_user.invite_code
+    user_code.save
+
+    assert_equal 0, user_code.invite_count
+  end
 end

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -2,12 +2,17 @@ require 'test_helper'
 
 class AccountTest < ActiveSupport::TestCase
 
+  setup do
+    @testcode = InviteCode.new
+    @testcode.save!
+  end
+
   teardown do
     Identity.destroy_all_disabled
   end
 
   test "create a new account" do
-    user = Account.create(FactoryGirl.attributes_for(:user))
+    user = Account.create(FactoryGirl.attributes_for(:user, :invite_code => @testcode.invite_code))
     assert user.valid?, "unexpected errors: #{user.errors.inspect}"
     assert user.persisted?
     assert id = user.identity
@@ -20,14 +25,14 @@ class AccountTest < ActiveSupport::TestCase
     # We keep an identity that will block the handle from being reused.
     assert_difference "Identity.count" do
       assert_no_difference "User.count" do
-        user = Account.create(FactoryGirl.attributes_for(:user))
+        user = Account.create(FactoryGirl.attributes_for(:user, :invite_code => @testcode.invite_code))
         user.account.destroy
       end
     end
   end
 
   test "change username and create alias" do
-    user = Account.create(FactoryGirl.attributes_for(:user))
+    user = Account.create(FactoryGirl.attributes_for(:user, :invite_code => @testcode.invite_code))
     old_id = user.identity
     old_email = user.email_address
     user.account.update(FactoryGirl.attributes_for(:user))

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -10,12 +10,39 @@ class InviteCodeTest < ActiveSupport::TestCase
   test "the invite code can be read from couch db correctly" do
     code1 = InviteCode.new
     code1.save
-
     code2 = InviteCode.find_by__id code1.id
-
     assert_equal code1.invite_code, code2.invite_code
-
   end
 
+  test "the invite code count gets set to 0 upon creation" do
+     code1 = InviteCode.new
+     code1.save
+     assert_equal code1.invite_count, 0
+  end
+
+   # TODO: does the count go up when code gets entered?
+   test "Invite code count goes up by 1 when the invite code is entered" do
+
+     validator = InviteCodeValidator.new nil
+
+     user = FactoryGirl.build :user
+     user_code = InviteCode.new
+     user_code.save
+     user.invite_code = user_code.invite_code
+
+
+     validator.validate(user)
+
+     user_code.reload
+     assert_equal 1, user_code.invite_count
+
+   end
+#
+#
+#   # TODO: count >0 is not accepted for signup
+   # test "Invite count >0 is not accepted for new account signup" do
+
+  #  end
 
 end
+

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,29 +20,64 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-   # TODO: does the count go up when code gets entered?
-   test "Invite code count goes up by 1 when the invite code is entered" do
+  test "Invite code count goes up by 1 when the invite code is entered" do
+    #TODO but onlz if there are no other errors on the form
 
-     validator = InviteCodeValidator.new nil
+    validator = InviteCodeValidator.new nil
 
-     user = FactoryGirl.build :user
-     user_code = InviteCode.new
-     user_code.save
-     user.invite_code = user_code.invite_code
+    user = FactoryGirl.build :user
+    user_code = InviteCode.new
+    user_code.save
+    user.invite_code = user_code.invite_code
 
+    validator.validate(user)
 
-     validator.validate(user)
+    user_code.reload
+    assert_equal 1, user_code.invite_count
 
-     user_code.reload
-     assert_equal 1, user_code.invite_count
+  end
 
-   end
-#
-#
-#   # TODO: count >0 is not accepted for signup
-   # test "Invite count >0 is not accepted for new account signup" do
+  test "Invite count >0 is not accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
 
-  #  end
+    user_code = InviteCode.new
+    user_code.invite_count = 1
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal ["This code has already been used"], user.errors[:invite_code]
+
+  end
+
+  test "Invite count 0 is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
+  end
+
+  test "There is an error message if the invite code does not exist" do
+    validator = InviteCodeValidator.new nil
+
+    user = FactoryGirl.build :user
+    user.invite_code = "wrongcode"
+
+    validator.validate(user)
+
+    assert_equal ["This is not a valid code"], user.errors[:invite_code]
+
+  end
+
 
 end
 

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class InviteCodeTest < ActiveSupport::TestCase
+
+  test "it is created with an invite code" do
+    code = InviteCode.new
+    assert_not_nil code.invite_code
+  end
+
+  test "the invite code can be read from couch db correctly" do
+    code1 = InviteCode.new
+    code1.save
+
+    code2 = InviteCode.find_by__id code1.id
+
+    assert_equal code1.invite_code, code2.invite_code
+
+  end
+
+
+end

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,22 +20,6 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-  test "Invite code count goes up by 1 when the invite code is entered" do
-    #TODO but onlz if there are no other errors on the form
-
-    validator = InviteCodeValidator.new nil
-
-    user = FactoryGirl.build :user
-    user_code = InviteCode.new
-    user_code.save
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    user_code.reload
-    assert_equal 1, user_code.invite_count
-
-  end
 
   test "Invite count >0 is not accepted for new account signup" do
     validator = InviteCodeValidator.new nil

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -10,7 +10,7 @@ class InviteCodeTest < ActiveSupport::TestCase
   test "the invite code can be read from couch db correctly" do
     code1 = InviteCode.new
     code1.save
-    code2 = InviteCode.find_by__id code1.id
+    code2 = InviteCode.find_by_invite_code code1.invite_code
     assert_equal code1.invite_code, code2.invite_code
   end
 

--- a/test/unit/invite_code_validator_test.rb
+++ b/test/unit/invite_code_validator_test.rb
@@ -16,7 +16,7 @@ class InviteCodeValidatorTest < ActiveSupport::TestCase
   end
 
   test "trying to create a user with invalid invite code should add error" do
-    invalid_user = FactoryGirl.build(:user)
+    invalid_user = FactoryGirl.build(:user, :invite_code => "a non-existent code")
 
     invalid_user.valid?
 

--- a/test/unit/invite_code_validator_test.rb
+++ b/test/unit/invite_code_validator_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class InviteCodeValidatorTest < ActiveSupport::TestCase
+  test "user should not be created with invalid invite code" do
+    invalid_user = FactoryGirl.build(:user)
+
+    assert !invalid_user.valid?
+  end
+
+  test "user should be created with valid invite code" do
+    valid_user = FactoryGirl.build(:user)
+    valid_code = InviteCode.create
+    valid_user.invite_code = valid_code.invite_code
+
+    assert valid_user.valid?
+  end
+
+  test "trying to create a user with invalid invite code should add error" do
+    invalid_user = FactoryGirl.build(:user)
+
+    invalid_user.valid?
+
+    errors = {invite_code: ["This is not a valid code"]}
+    assert_equal errors, invalid_user.errors.messages
+  end
+end

--- a/test/unit/invite_code_validator_test.rb
+++ b/test/unit/invite_code_validator_test.rb
@@ -2,9 +2,11 @@ require 'test_helper'
 
 class InviteCodeValidatorTest < ActiveSupport::TestCase
   test "user should not be created with invalid invite code" do
+    with_config invite_required: true do
     invalid_user = FactoryGirl.build(:user)
 
     assert !invalid_user.valid?
+    end
   end
 
   test "user should be created with valid invite code" do
@@ -16,11 +18,13 @@ class InviteCodeValidatorTest < ActiveSupport::TestCase
   end
 
   test "trying to create a user with invalid invite code should add error" do
+    with_config invite_required: true do
     invalid_user = FactoryGirl.build(:user, :invite_code => "a non-existent code")
 
     invalid_user.valid?
 
     errors = {invite_code: ["This is not a valid code"]}
     assert_equal errors, invalid_user.errors.messages
+    end
   end
 end

--- a/test/unit/tmp_user_test.rb
+++ b/test/unit/tmp_user_test.rb
@@ -2,19 +2,23 @@ require 'test_helper'
 
 class TmpUserTest < ActiveSupport::TestCase
 
+  setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+  end
+
   test "test_user saved to tmp_users" do
     begin
       assert User.ancestors.include?(TemporaryUser)
 
       assert_difference('User.database.info["doc_count"]') do
         normal_user = User.create!(:login => 'a'+SecureRandom.hex(5).downcase,
-          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF', :invite_code => 'testcode')
+          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF')
         refute normal_user.database.to_s.include?('tmp')
       end
 
       assert_difference('User.tmp_database.info["doc_count"]') do
         tmp_user = User.create!(:login => 'test_user_'+SecureRandom.hex(5).downcase,
-          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF', :invite_code => 'testcode')
+          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF')
         assert tmp_user.database.to_s.include?('tmp')
       end
     ensure

--- a/test/unit/tmp_user_test.rb
+++ b/test/unit/tmp_user_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TmpUserTest < ActiveSupport::TestCase
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
   end
 
   test "test_user saved to tmp_users" do

--- a/test/unit/tmp_user_test.rb
+++ b/test/unit/tmp_user_test.rb
@@ -8,13 +8,13 @@ class TmpUserTest < ActiveSupport::TestCase
 
       assert_difference('User.database.info["doc_count"]') do
         normal_user = User.create!(:login => 'a'+SecureRandom.hex(5).downcase,
-          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF')
+          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF', :invite_code => 'testcode')
         refute normal_user.database.to_s.include?('tmp')
       end
 
       assert_difference('User.tmp_database.info["doc_count"]') do
         tmp_user = User.create!(:login => 'test_user_'+SecureRandom.hex(5).downcase,
-          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF')
+          :password_verifier => 'ABCDEF0010101', :password_salt => 'ABCDEF', :invite_code => 'testcode')
         assert tmp_user.database.to_s.include?('tmp')
       end
     ensure

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -4,6 +4,7 @@ class TokenTest < ActiveSupport::TestCase
   include StubRecordHelper
 
   setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
     @user = find_record :user
   end
 

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -4,7 +4,7 @@ class TokenTest < ActiveSupport::TestCase
   include StubRecordHelper
 
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
     @user = find_record :user
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -4,7 +4,7 @@ class UserTest < ActiveSupport::TestCase
 
   include SRP::Util
   setup do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
+    InviteCodeValidator.any_instance.stubs(:validate)
     @user = FactoryGirl.build(:user)
   end
 
@@ -71,26 +71,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal key, @user.public_key
   end
 
-  test "user should not be created with invalid invite code" do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(true)
-    invalid_user = FactoryGirl.build(:user)
 
-    assert !invalid_user.valid?
-  end
-
-  test "user should be created with valid invite code" do
-    assert @user.valid?
-  end
-
-  test "trying to create a user with invalid invite code should add error" do
-    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(true)
-    invalid_user = FactoryGirl.build(:user)
-
-    invalid_user.valid?
-
-    errors = {invite_code: ["This is not a valid code"]}
-    assert_equal errors, invalid_user.errors.messages
-  end
 
   #
   ## Regression tests

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -4,6 +4,7 @@ class UserTest < ActiveSupport::TestCase
 
   include SRP::Util
   setup do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(false)
     @user = FactoryGirl.build(:user)
   end
 
@@ -70,9 +71,25 @@ class UserTest < ActiveSupport::TestCase
     assert_equal key, @user.public_key
   end
 
-  test "user should have an invite token" do
-    user = User.new
-    assert_nil(user.invite_code)
+  test "user should not be created with invalid invite code" do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(true)
+    invalid_user = FactoryGirl.build(:user)
+
+    assert !invalid_user.valid?
+  end
+
+  test "user should be created with valid invite code" do
+    assert @user.valid?
+  end
+
+  test "trying to create a user with invalid invite code should add error" do
+    InviteCodeValidator.any_instance.stubs(:not_existent?).returns(true)
+    invalid_user = FactoryGirl.build(:user)
+
+    invalid_user.valid?
+
+    errors = {invite_code: ["This is not a valid code"]}
+    assert_equal errors, invalid_user.errors.messages
   end
 
   #

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -70,6 +70,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal key, @user.public_key
   end
 
+  test "user should have an invite token" do
+    user = User.new
+    assert_nil(user.invite_code)
+  end
+
   #
   ## Regression tests
   #


### PR DESCRIPTION
Hey @elijh and @azul! 

We're Aya and Anke from the Rails Girls Summer of Code and we've been working on the invite code feature for the past few weeks. We wanted to let you know what we've done so far and see if you're happy with the invite code feature as it is. We don't expect you to merge our changes yet because one important feature is still missing (as discussed with Azul).

Here is a list of the changes we made: 
- added invite code field to the sign-up form
- added validation for invite code
- added rake tasks so the admins can generate invite codes
- using the coupon code gem to generate the invite codes

What's missing: 
- allow provider to turn the invite code on and off (this feature is crucial before our code is merged as discussed with Azul)
- separating srp  from our code so we don't have to make changes to srp
- add some nice-to-have features e.g. use multi-use invite codes, expiration dates for invite code, allowing admins to change code from the web interface

Here's a link to our github issues where we track what we're working on:
https://github.com/Alster-Hamburgers/leap_web/issues

Please let us know how you like it and if you have any feedback. We still have a few more weeks left to work on the missing features and implement changes. 

Best, 
Anke and Aya 


