### PR TITLE
couchrest_model 2.0.1 fixes find_by_sth(nil)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       mime-types (~> 1.15)
       multi_json (~> 1.0)
       rest-client (~> 1.6.1)
-    couchrest_model (2.0.0)
+    couchrest_model (2.0.1)
       activemodel (>= 3.0)
       couchrest (~> 1.1.3)
       mime-types (>= 1.15)
@@ -139,7 +139,7 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.3)
     kaminari (0.13.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -156,7 +156,7 @@ GEM
     minitest-stub-const (0.2)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
+    multi_json (1.11.2)
     multi_test (0.1.1)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
@@ -204,9 +204,8 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (2.0.0)
-    rest-client (1.6.8)
+    rest-client (1.6.9)
       mime-types (~> 1.16)
-      rdoc (>= 2.4.2)
     ruby-srp (0.2.1)
     sass (3.4.9)
     sass-rails (3.2.6)
@@ -239,7 +238,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.42)
+    tzinfo (0.3.44)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
@@ -297,6 +296,3 @@ DEPENDENCIES
   thin
   uglifier (~> 1.2.7)
   valid_email
-
-BUNDLED WITH
-   1.10.6

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -7,6 +7,11 @@ class UserTest < ActiveSupport::TestCase
     @user = FactoryGirl.build(:user)
   end
 
+  test "don't find a user with login nil" do
+    @user.save
+    assert_nil User.find_by_login(nil)
+  end
+
   test "design docs in database are authorative" do
     assert !User.design_doc.auto_update,
       "Automatic update of design docs should be disabled"


### PR DESCRIPTION
This used to return the first record! :scream:

This [commit in couchrest_model](https://github.com/couchrest/couchrest_model/commit/2c5b76823e94caed4d8cbfbf18cb9e0d58789789) is essential for say User.find_by_login(nil) to NOT return the first record in the database.