### PR TITLE
Add the localization keys for invite_code and password_confirmation

### DIFF
--- a/lib/en_US.yml
+++ b/lib/en_US.yml
@@ -119,6 +119,8 @@ en_US:
   account_settings: Account Settings
   username: Username
   password: Password
+  password_confirmation: Password confirmation
+  invite_code: Invite code
   change_password: Change Password
   invalid_user_pass: Not a valid username/password combination
   invalid_ephemeral: Invalid random key used. This looked like an attempt to hack the


### PR DESCRIPTION
This adds the localization keys for invite_code (needed for the invite code feature) and for password_confirmation (which was missing). 

