### PR TITLE
Allow multi-use invite codes

### DIFF
--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -4,12 +4,14 @@ class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
   property :invite_code, String, :read_only => true
   property :invite_count, Integer, :default => 0, :accessible => true
+  property :invite_max_uses, Integer, :default => 1, :accessible => true
 
   timestamps!
 
   design do
     view :by_invite_code
     view :by_invite_count
+    view :by_invite_max_uses
   end
 
   def initialize(attributes = {}, options = {})

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -4,14 +4,13 @@ class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
   property :invite_code, String, :read_only => true
   property :invite_count, Integer, :default => 0, :accessible => true
-  property :invite_max_uses, Integer, :default => 1, :accessible => true
+  property :max_uses, Integer, :default => 1
 
   timestamps!
 
   design do
     view :by_invite_code
     view :by_invite_count
-    view :by_invite_max_uses
   end
 
   def initialize(attributes = {}, options = {})

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -18,7 +18,7 @@ class InviteCodeValidator < ActiveModel::Validator
   end
 
   def has_no_uses_left?(code)
-    code.invite_count >= code.invite_max_uses
+    code.invite_count >= code.max_uses
   end
 
   def add_error_to_user(error, user)

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -1,4 +1,5 @@
 class InviteCodeValidator < ActiveModel::Validator
+
   def validate(user)
 
     user_invite_code = InviteCode.find_by_invite_code user.invite_code
@@ -8,9 +9,6 @@ class InviteCodeValidator < ActiveModel::Validator
 
     elsif has_no_uses_left?(user_invite_code)
       add_error_to_user("This code has already been used", user)
-
-    # elsif count_greater_than_zero?(user_invite_code)
-    #   add_error_to_user("This code has already been used", user)
     end
   end
 
@@ -22,10 +20,6 @@ class InviteCodeValidator < ActiveModel::Validator
   def has_no_uses_left?(code)
     code.invite_count >= code.invite_max_uses
   end
-
-  # def count_greater_than_zero?(code)
-  #   code.invite_count > 0
-  # end
 
   def add_error_to_user(error, user)
     user.errors[:invite_code] << error

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -6,8 +6,11 @@ class InviteCodeValidator < ActiveModel::Validator
     if not_existent?(user_invite_code)
       add_error_to_user("This is not a valid code", user)
 
-    elsif count_greater_than_zero?(user_invite_code)
+    elsif has_no_uses_left?(user_invite_code)
       add_error_to_user("This code has already been used", user)
+
+    # elsif count_greater_than_zero?(user_invite_code)
+    #   add_error_to_user("This code has already been used", user)
     end
   end
 
@@ -16,9 +19,13 @@ class InviteCodeValidator < ActiveModel::Validator
     code == nil
   end
 
-  def count_greater_than_zero?(code)
-    code.invite_count > 0
+  def has_no_uses_left?(code)
+    code.invite_count >= code.invite_max_uses
   end
+
+  # def count_greater_than_zero?(code)
+  #   code.invite_count > 0
+  # end
 
   def add_error_to_user(error, user)
     user.errors[:invite_code] << error

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -16,9 +16,9 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
 
   codes.times do |x|
     x = InviteCode.new
-    x.invite_max_uses = max_uses
+    x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code} Code generated with #{x.invite_max_uses} uses."
+    puts "#{x.invite_code} Code generated with #{x.max_uses} uses."
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -18,7 +18,7 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     x = InviteCode.new
     x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code}"
+    puts x.invite_code
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,16 +1,25 @@
 
 
 desc "Generate a batch of invite codes"
-task :generate_invites, [:n] => :environment do |task, args|
+task :generate_invites, [:n, :u] => :environment do |task, args|
 
-    codes = args.n
-    codes = codes.to_i
+  codes = args.n
+  codes = codes.to_i
 
-    codes.times do |x|
-    x = InviteCode.new
-    x.save
-    puts "#{x.invite_code} Code generated."
+  if args.u == nil
+    max_uses = 1
 
+  elsif
+    max_uses = args.u
+    max_uses = max_uses.to_i
   end
+
+  codes.times do |x|
+    x = InviteCode.new
+    x.invite_max_uses = max_uses
+    x.save
+    puts "#{x.invite_code} Code generated with #{x.invite_max_uses} uses."
+  end
+
 end
 

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -18,7 +18,7 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     x = InviteCode.new
     x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code} Code generated with #{x.max_uses} uses."
+    puts "#{x.invite_code}"
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -6,12 +6,8 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
   codes = args.n
   codes = codes.to_i
 
-  if args.u == nil
-    max_uses = 1
-
-  elsif
+  if args.u != nil
     max_uses = args.u
-    max_uses = max_uses.to_i
   end
 
   codes.times do |x|

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,23 +20,6 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-
-  # test "Invite count >0 is not accepted for new account signup" do
-  #   validator = InviteCodeValidator.new nil
-  #
-  #   user_code = InviteCode.new
-  #   user_code.invite_count = 1
-  #   user_code.save
-  #
-  #   user = FactoryGirl.build :user
-  #   user.invite_code = user_code.invite_code
-  #
-  #   validator.validate(user)
-  #
-  #   assert_equal ["This code has already been used"], user.errors[:invite_code]
-  #
-  # end
-
   test "Invite count >= invite max uses is not accepted for new account signup" do
     validator = InviteCodeValidator.new nil
 

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -21,11 +21,28 @@ class InviteCodeTest < ActiveSupport::TestCase
   end
 
 
-  test "Invite count >0 is not accepted for new account signup" do
+  # test "Invite count >0 is not accepted for new account signup" do
+  #   validator = InviteCodeValidator.new nil
+  #
+  #   user_code = InviteCode.new
+  #   user_code.invite_count = 1
+  #   user_code.save
+  #
+  #   user = FactoryGirl.build :user
+  #   user.invite_code = user_code.invite_code
+  #
+  #   validator.validate(user)
+  #
+  #   assert_equal ["This code has already been used"], user.errors[:invite_code]
+  #
+  # end
+
+  test "Invite count >= invite max uses is not accepted for new account signup" do
     validator = InviteCodeValidator.new nil
 
     user_code = InviteCode.new
     user_code.invite_count = 1
+    user_code.invite_max_uses = 1
     user_code.save
 
     user = FactoryGirl.build :user
@@ -35,6 +52,22 @@ class InviteCodeTest < ActiveSupport::TestCase
 
     assert_equal ["This code has already been used"], user.errors[:invite_code]
 
+  end
+
+  test "Invite count < invite max uses is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+    user_code.invite_count = 0
+    user_code.invite_max_uses = 1
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
   end
 
   test "Invite count 0 is accepted for new account signup" do
@@ -61,7 +94,6 @@ class InviteCodeTest < ActiveSupport::TestCase
     assert_equal ["This is not a valid code"], user.errors[:invite_code]
 
   end
-
 
 end
 

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,63 +20,6 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-  test "Invite count >= invite max uses is not accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.new
-    user_code.invite_count = 1
-    user_code.invite_max_uses = 1
-    user_code.save
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal ["This code has already been used"], user.errors[:invite_code]
-
-  end
-
-  test "Invite count < invite max uses is accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.create
-    user_code.invite_count = 0
-    user_code.invite_max_uses = 1
-    user_code.save
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal [], user.errors[:invite_code]
-  end
-
-  test "Invite count 0 is accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.create
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal [], user.errors[:invite_code]
-  end
-
-  test "There is an error message if the invite code does not exist" do
-    validator = InviteCodeValidator.new nil
-
-    user = FactoryGirl.build :user
-    user.invite_code = "wrongcode"
-
-    validator.validate(user)
-
-    assert_equal ["This is not a valid code"], user.errors[:invite_code]
-
-  end
 
 end
 

--- a/test/unit/invite_code_validator_test.rb
+++ b/test/unit/invite_code_validator_test.rb
@@ -27,4 +27,60 @@ class InviteCodeValidatorTest < ActiveSupport::TestCase
     assert_equal errors, invalid_user.errors.messages
     end
   end
+
+
+  test "Invite count >= invite max uses is not accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.new
+    user_code.invite_count = 1
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal ["This code has already been used"], user.errors[:invite_code]
+
+  end
+
+  test "Invite count < invite max uses is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
+  end
+
+  test "Invite count 0 is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
+  end
+
+  test "There is an error message if the invite code does not exist" do
+    validator = InviteCodeValidator.new nil
+
+    user = FactoryGirl.build :user
+    user.invite_code = "wrongcode"
+
+    validator.validate(user)
+
+    assert_equal ["This is not a valid code"], user.errors[:invite_code]
+  end
+
 end


### PR DESCRIPTION
This will allow admins to generate invite codes and specify the number of times they can be used to create new accounts. (If no number if specified, single-use invite codes will be generated.) 

This is done by introducing a max_uses property and comparing the invite count to the maximum number of uses, and adding an optional parameter to the rake task. 