### PR TITLE
Remove Coupon Code gem and prepare for easy platform test deletion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ end
 ## AUTHENTICATION
 gem "ruby-srp", "~> 0.2.1"
 gem "rails_warden"
-gem "coupon_code"
 
 ## LOCALIZATION
 gem 'http_accept_language'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,6 @@ GEM
       actionpack (~> 3.0)
       couchrest
       couchrest_model
-    coupon_code (0.0.1)
     cucumber (1.3.17)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -277,7 +276,6 @@ DEPENDENCIES
   couchrest (~> 1.1.3)
   couchrest_model (~> 2.0.0)
   couchrest_session_store (= 0.3.0)
-  coupon_code
   cucumber-rails
   debugger
   factory_girl_rails
@@ -307,3 +305,6 @@ DEPENDENCIES
   thin
   uglifier (~> 1.2.7)
   valid_email
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -20,7 +20,7 @@ class InviteCode < CouchRest::Model::Base
     end
 
     super(attributes, options)
-    
+
     write_attribute('invite_code', attributes[:id]) if new?
   end
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,3 +1,5 @@
+require 'base64'
+require 'securerandom'
 
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
@@ -14,8 +16,12 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
-    write_attribute('invite_code', CouponCode.generate) if new?
+    write_attribute('invite_code', generate_invite) if new?
 
+  end
+
+  def generate_invite
+    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
   end
 
   def set_invite_code(code)

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -4,12 +4,14 @@ class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
   property :invite_code, String, :read_only => true
   property :invite_count, Integer, :default => 0, :accessible => true
+  property :invite_max_uses, Integer, :default => 1, :accessible => true
 
   timestamps!
 
   design do
     view :by_invite_code
     view :by_invite_count
+    view :by_invite_max_uses
   end
 
   def initialize(attributes = {}, options = {})

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -4,14 +4,13 @@ class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
   property :invite_code, String, :read_only => true
   property :invite_count, Integer, :default => 0, :accessible => true
-  property :invite_max_uses, Integer, :default => 1, :accessible => true
+  property :max_uses, Integer, :default => 1
 
   timestamps!
 
   design do
     view :by_invite_code
     view :by_invite_count
-    view :by_invite_max_uses
   end
 
   def initialize(attributes = {}, options = {})

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,4 +1,3 @@
-require 'coupon_code'
 
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
@@ -15,9 +14,11 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
-    write_attribute('invite_code', CouponCode.generate) if new?
   end
 
+  def set_invite_code(code)
+    write_attribute(:invite_code, code)
+  end
 end
 
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -14,6 +14,8 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
+    write_attribute('invite_code', CouponCode.generate) if new?
+
   end
 
   def set_invite_code(code)

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -15,17 +15,17 @@ class InviteCode < CouchRest::Model::Base
   end
 
   def initialize(attributes = {}, options = {})
+    if !attributes.has_key?("_id")
+      attributes[:id] = InviteCode.generate_invite
+    end
+
     super(attributes, options)
-    write_attribute('invite_code', generate_invite) if new?
 
+    write_attribute('invite_code', attributes[:id]) if new?
   end
 
-  def generate_invite
+  def self.generate_invite
     Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
-  end
-
-  def set_invite_code(code)
-    write_attribute(:invite_code, code)
   end
 end
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -20,7 +20,7 @@ class InviteCode < CouchRest::Model::Base
     end
 
     super(attributes, options)
-
+    
     write_attribute('invite_code', attributes[:id]) if new?
   end
 

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -18,7 +18,7 @@ class InviteCodeValidator < ActiveModel::Validator
   end
 
   def has_no_uses_left?(code)
-    code.invite_count >= code.invite_max_uses
+    code.invite_count >= code.max_uses
   end
 
   def add_error_to_user(error, user)

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -1,4 +1,5 @@
 class InviteCodeValidator < ActiveModel::Validator
+
   def validate(user)
 
     user_invite_code = InviteCode.find_by_invite_code user.invite_code
@@ -8,9 +9,6 @@ class InviteCodeValidator < ActiveModel::Validator
 
     elsif has_no_uses_left?(user_invite_code)
       add_error_to_user("This code has already been used", user)
-
-    # elsif count_greater_than_zero?(user_invite_code)
-    #   add_error_to_user("This code has already been used", user)
     end
   end
 
@@ -22,10 +20,6 @@ class InviteCodeValidator < ActiveModel::Validator
   def has_no_uses_left?(code)
     code.invite_count >= code.invite_max_uses
   end
-
-  # def count_greater_than_zero?(code)
-  #   code.invite_count > 0
-  # end
 
   def add_error_to_user(error, user)
     user.errors[:invite_code] << error

--- a/app/models/invite_code_validator.rb
+++ b/app/models/invite_code_validator.rb
@@ -6,8 +6,11 @@ class InviteCodeValidator < ActiveModel::Validator
     if not_existent?(user_invite_code)
       add_error_to_user("This is not a valid code", user)
 
-    elsif count_greater_than_zero?(user_invite_code)
+    elsif has_no_uses_left?(user_invite_code)
       add_error_to_user("This code has already been used", user)
+
+    # elsif count_greater_than_zero?(user_invite_code)
+    #   add_error_to_user("This code has already been used", user)
     end
   end
 
@@ -16,9 +19,13 @@ class InviteCodeValidator < ActiveModel::Validator
     code == nil
   end
 
-  def count_greater_than_zero?(code)
-    code.invite_count > 0
+  def has_no_uses_left?(code)
+    code.invite_count >= code.invite_max_uses
   end
+
+  # def count_greater_than_zero?(code)
+  #   code.invite_count > 0
+  # end
 
   def add_error_to_user(error, user)
     user.errors[:invite_code] << error

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -16,9 +16,9 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
 
   codes.times do |x|
     x = InviteCode.new
-    x.invite_max_uses = max_uses
+    x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code} Code generated with #{x.invite_max_uses} uses."
+    puts "#{x.invite_code} Code generated with #{x.max_uses} uses."
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -18,7 +18,7 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     x = InviteCode.new
     x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code}"
+    puts x.invite_code
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,16 +1,25 @@
 
 
 desc "Generate a batch of invite codes"
-task :generate_invites, [:n] => :environment do |task, args|
+task :generate_invites, [:n, :u] => :environment do |task, args|
 
-    codes = args.n
-    codes = codes.to_i
+  codes = args.n
+  codes = codes.to_i
 
-    codes.times do |x|
-    x = InviteCode.new
-    x.save
-    puts "#{x.invite_code} Code generated."
+  if args.u == nil
+    max_uses = 1
 
+  elsif
+    max_uses = args.u
+    max_uses = max_uses.to_i
   end
+
+  codes.times do |x|
+    x = InviteCode.new
+    x.invite_max_uses = max_uses
+    x.save
+    puts "#{x.invite_code} Code generated with #{x.invite_max_uses} uses."
+  end
+
 end
 

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -11,10 +11,6 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = args.u
   end
 
-  def generate_invite
-    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
-  end
-
   codes.times do |x|
     x = InviteCode.new
     x.max_uses = max_uses

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -18,7 +18,7 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     x = InviteCode.new
     x.max_uses = max_uses
     x.save
-    puts "#{x.invite_code} Code generated with #{x.max_uses} uses."
+    puts "#{x.invite_code}"
   end
 
 end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -11,6 +11,10 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = args.u
   end
 
+  def generate_invite
+    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
+  end
+
   codes.times do |x|
     x = InviteCode.new
     x.max_uses = max_uses

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,4 +1,5 @@
-require 'coupon_code'
+require 'base64'
+require 'securerandom'
 
 desc "Generate a batch of invite codes"
 task :generate_invites, [:n, :u] => :environment do |task, args|
@@ -14,8 +15,12 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = max_uses.to_i
   end
 
+  def generate_invite
+    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
+  end
+
   codes.times do |x|
-    new_code = CouponCode.generate
+    new_code = generate_invite
 
     x = InviteCode.new(:id => new_code)
     x.set_invite_code(new_code)

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -15,15 +15,8 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = max_uses.to_i
   end
 
-  def generate_invite
-    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
-  end
-
   codes.times do |x|
-    new_code = generate_invite
-
-    x = InviteCode.new(:id => new_code)
-    x.set_invite_code(new_code)
+    x = InviteCode.new
     x.max_uses = max_uses
     x.save
     puts x.invite_code

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -7,12 +7,8 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
   codes = args.n
   codes = codes.to_i
 
-  if args.u == nil
-    max_uses = 1
-
-  elsif
+  if args.u != nil
     max_uses = args.u
-    max_uses = max_uses.to_i
   end
 
   codes.times do |x|

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,4 +1,4 @@
-
+require 'coupon_code'
 
 desc "Generate a batch of invite codes"
 task :generate_invites, [:n, :u] => :environment do |task, args|
@@ -15,7 +15,10 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
   end
 
   codes.times do |x|
-    x = InviteCode.new
+    new_code = CouponCode.generate
+
+    x = InviteCode.new(:id => new_code)
+    x.set_invite_code(new_code)
     x.max_uses = max_uses
     x.save
     puts x.invite_code

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,23 +20,6 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-
-  # test "Invite count >0 is not accepted for new account signup" do
-  #   validator = InviteCodeValidator.new nil
-  #
-  #   user_code = InviteCode.new
-  #   user_code.invite_count = 1
-  #   user_code.save
-  #
-  #   user = FactoryGirl.build :user
-  #   user.invite_code = user_code.invite_code
-  #
-  #   validator.validate(user)
-  #
-  #   assert_equal ["This code has already been used"], user.errors[:invite_code]
-  #
-  # end
-
   test "Invite count >= invite max uses is not accepted for new account signup" do
     validator = InviteCodeValidator.new nil
 

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -21,11 +21,28 @@ class InviteCodeTest < ActiveSupport::TestCase
   end
 
 
-  test "Invite count >0 is not accepted for new account signup" do
+  # test "Invite count >0 is not accepted for new account signup" do
+  #   validator = InviteCodeValidator.new nil
+  #
+  #   user_code = InviteCode.new
+  #   user_code.invite_count = 1
+  #   user_code.save
+  #
+  #   user = FactoryGirl.build :user
+  #   user.invite_code = user_code.invite_code
+  #
+  #   validator.validate(user)
+  #
+  #   assert_equal ["This code has already been used"], user.errors[:invite_code]
+  #
+  # end
+
+  test "Invite count >= invite max uses is not accepted for new account signup" do
     validator = InviteCodeValidator.new nil
 
     user_code = InviteCode.new
     user_code.invite_count = 1
+    user_code.invite_max_uses = 1
     user_code.save
 
     user = FactoryGirl.build :user
@@ -35,6 +52,22 @@ class InviteCodeTest < ActiveSupport::TestCase
 
     assert_equal ["This code has already been used"], user.errors[:invite_code]
 
+  end
+
+  test "Invite count < invite max uses is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+    user_code.invite_count = 0
+    user_code.invite_max_uses = 1
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
   end
 
   test "Invite count 0 is accepted for new account signup" do
@@ -61,7 +94,6 @@ class InviteCodeTest < ActiveSupport::TestCase
     assert_equal ["This is not a valid code"], user.errors[:invite_code]
 
   end
-
 
 end
 

--- a/test/unit/invite_code_test.rb
+++ b/test/unit/invite_code_test.rb
@@ -20,63 +20,6 @@ class InviteCodeTest < ActiveSupport::TestCase
      assert_equal code1.invite_count, 0
   end
 
-  test "Invite count >= invite max uses is not accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.new
-    user_code.invite_count = 1
-    user_code.invite_max_uses = 1
-    user_code.save
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal ["This code has already been used"], user.errors[:invite_code]
-
-  end
-
-  test "Invite count < invite max uses is accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.create
-    user_code.invite_count = 0
-    user_code.invite_max_uses = 1
-    user_code.save
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal [], user.errors[:invite_code]
-  end
-
-  test "Invite count 0 is accepted for new account signup" do
-    validator = InviteCodeValidator.new nil
-
-    user_code = InviteCode.create
-
-    user = FactoryGirl.build :user
-    user.invite_code = user_code.invite_code
-
-    validator.validate(user)
-
-    assert_equal [], user.errors[:invite_code]
-  end
-
-  test "There is an error message if the invite code does not exist" do
-    validator = InviteCodeValidator.new nil
-
-    user = FactoryGirl.build :user
-    user.invite_code = "wrongcode"
-
-    validator.validate(user)
-
-    assert_equal ["This is not a valid code"], user.errors[:invite_code]
-
-  end
 
 end
 

--- a/test/unit/invite_code_validator_test.rb
+++ b/test/unit/invite_code_validator_test.rb
@@ -27,4 +27,60 @@ class InviteCodeValidatorTest < ActiveSupport::TestCase
     assert_equal errors, invalid_user.errors.messages
     end
   end
+
+
+  test "Invite count >= invite max uses is not accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.new
+    user_code.invite_count = 1
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal ["This code has already been used"], user.errors[:invite_code]
+
+  end
+
+  test "Invite count < invite max uses is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+    user_code.save
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
+  end
+
+  test "Invite count 0 is accepted for new account signup" do
+    validator = InviteCodeValidator.new nil
+
+    user_code = InviteCode.create
+
+    user = FactoryGirl.build :user
+    user.invite_code = user_code.invite_code
+
+    validator.validate(user)
+
+    assert_equal [], user.errors[:invite_code]
+  end
+
+  test "There is an error message if the invite code does not exist" do
+    validator = InviteCodeValidator.new nil
+
+    user = FactoryGirl.build :user
+    user.invite_code = "wrongcode"
+
+    validator.validate(user)
+
+    assert_equal ["This is not a valid code"], user.errors[:invite_code]
+  end
+
 end


### PR DESCRIPTION
This will 
a) remove the Coupon Code gem as suggested by Elijah and 
b) set the invite code id to be the same as the invite code - this way, after running the platform test, it will be easier to delete the invite codes because we won't have to look up their id each time after the test runs.