### PR TITLE
Remove Coupon Code gem and set invite code = id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ end
 ## AUTHENTICATION
 gem "ruby-srp", "~> 0.2.1"
 gem "rails_warden"
-gem "coupon_code"
 
 ## LOCALIZATION
 gem 'http_accept_language'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,6 @@ GEM
       actionpack (~> 3.0)
       couchrest
       couchrest_model
-    coupon_code (0.0.1)
     cucumber (1.3.17)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -277,7 +276,6 @@ DEPENDENCIES
   couchrest (~> 1.1.3)
   couchrest_model (~> 2.0.0)
   couchrest_session_store (= 0.3.0)
-  coupon_code
   cucumber-rails
   debugger
   factory_girl_rails
@@ -307,3 +305,6 @@ DEPENDENCIES
   thin
   uglifier (~> 1.2.7)
   valid_email
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -19,7 +19,7 @@ class InviteCode < CouchRest::Model::Base
     end
 
     super(attributes, options)
-    
+
     write_attribute('invite_code', attributes[:id]) if new?
   end
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,4 +1,3 @@
-require 'coupon_code'
 
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
@@ -14,9 +13,11 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
-    write_attribute('invite_code', CouponCode.generate) if new?
   end
 
+  def set_invite_code(code)
+    write_attribute(:invite_code, code)
+  end
 end
 
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -1,3 +1,5 @@
+require 'base64'
+require 'securerandom'
 
 class InviteCode < CouchRest::Model::Base
   use_database 'invite_codes'
@@ -13,8 +15,12 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
-    write_attribute('invite_code', CouponCode.generate) if new?
+    write_attribute('invite_code', generate_invite) if new?
 
+  end
+
+  def generate_invite
+    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
   end
 
   def set_invite_code(code)

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -13,6 +13,8 @@ class InviteCode < CouchRest::Model::Base
 
   def initialize(attributes = {}, options = {})
     super(attributes, options)
+    write_attribute('invite_code', CouponCode.generate) if new?
+
   end
 
   def set_invite_code(code)

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -14,17 +14,17 @@ class InviteCode < CouchRest::Model::Base
   end
 
   def initialize(attributes = {}, options = {})
+    if !attributes.has_key?("_id")
+      attributes[:id] = InviteCode.generate_invite
+    end
+
     super(attributes, options)
-    write_attribute('invite_code', generate_invite) if new?
 
+    write_attribute('invite_code', attributes[:id]) if new?
   end
 
-  def generate_invite
+  def self.generate_invite
     Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
-  end
-
-  def set_invite_code(code)
-    write_attribute(:invite_code, code)
   end
 end
 

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -19,7 +19,7 @@ class InviteCode < CouchRest::Model::Base
     end
 
     super(attributes, options)
-
+    
     write_attribute('invite_code', attributes[:id]) if new?
   end
 

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -11,10 +11,6 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = args.u
   end
 
-  def generate_invite
-    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
-  end
-
   codes.times do |x|
     x = InviteCode.new
     x.max_uses = max_uses

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -11,6 +11,10 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
     max_uses = args.u
   end
 
+  def generate_invite
+    Base64.encode64(SecureRandom.random_bytes).downcase.gsub(/[0oil1+_\/]/,'')[0..7].scan(/..../).join('-')
+  end
+
   codes.times do |x|
     x = InviteCode.new
     x.max_uses = max_uses

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,16 +1,21 @@
-
+require 'base64'
+require 'securerandom'
 
 desc "Generate a batch of invite codes"
-task :generate_invites, [:n] => :environment do |task, args|
+task :generate_invites, [:n, :u] => :environment do |task, args|
 
-    codes = args.n
-    codes = codes.to_i
+  codes = args.n
+  codes = codes.to_i
 
-    codes.times do |x|
-    x = InviteCode.new
-    x.save
-    puts "#{x.invite_code} Code generated."
-
+  if args.u != nil
+    max_uses = args.u
   end
-end
 
+  codes.times do |x|
+    x = InviteCode.new
+    x.max_uses = max_uses
+    x.save
+    puts x.invite_code
+  end
+
+end

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -19,3 +19,4 @@ task :generate_invites, [:n, :u] => :environment do |task, args|
   end
 
 end
+

--- a/lib/tasks/invite_code.rake
+++ b/lib/tasks/invite_code.rake
@@ -1,19 +1,11 @@
-require 'base64'
-require 'securerandom'
-
 desc "Generate a batch of invite codes"
-task :generate_invites, [:n, :u] => :environment do |task, args|
+task :generate_invites, [:n] => :environment do |task, args|
 
   codes = args.n
   codes = codes.to_i
 
-  if args.u != nil
-    max_uses = args.u
-  end
-
   codes.times do |x|
     x = InviteCode.new
-    x.max_uses = max_uses
     x.save
     puts x.invite_code
   end


### PR DESCRIPTION
This does two things:

a) it removes the Coupon Code gem and replaces it as suggested by Elijah

b) it sets the id = the invite code, which will help with invite code deletion after the leap platform tests run.