### PR TITLE
Handle conflict on token cleanup - fixes #7670

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -59,7 +59,8 @@ class Token < CouchRest::Model::Base
   # So let's make sure we don't crash if they disappeared
   def destroy_with_rescue
     destroy_without_rescue
-  rescue RestClient::ResourceNotFound
+  rescue RestClient::ResourceNotFound # do nothing it's gone already
+  rescue RestClient::Conflict # do nothing - it's been updated - #7670
   end
   alias_method_chain :destroy, :rescue
 


### PR DESCRIPTION
the only race condition I can think of here is this...

    somebody tries to authenticate with a token that is almost expired.
    auth checks and notices it is not expired yet so starts to prolonge it.
    Before the polonged token is written to the db the cleanup script discovers that it has just expired.
    prolonged token is written to the db
    cleanup script fails to delete it from the db as it has been updated.

So what we want in this case is to keep the token alive as it was renewed in the last minute.