### PR TITLE
remove outdated couchrest hack

### DIFF
--- a/lib/extensions/couchrest.rb
+++ b/lib/extensions/couchrest.rb
@@ -32,23 +32,6 @@ module CouchRest
       end
     end
 
-    module Connection
-
-      module ClassMethods
-
-        def use_database(db)
-          @database = prepare_database(db)
-        rescue RestClient::Exception,
-          Errno::EHOSTUNREACH,
-          Errno::ECONNREFUSED => e
-          message = "Could not connect to couch database #{db} due to #{e.to_s}"
-          Rails.logger.warn message
-          raise e.class.new(message) if APP_CONFIG[:reraise_errors]
-        end
-      end
-
-    end
-
     module Utils
       module Migrate
         def self.load_all_models_with_engines


### PR DESCRIPTION
We had rewritten use_database so it would not crash the entire app
if couch was not available at the time of initialization.

couchrest now moved on and only sets the database name on use_database.
The database will only be queried once it is really needed. So pretty
much exactly what we want.

Our hack instead caused quite a bit of problems as it would still
initialize the database during start. This way the app would remain
in an invalid state even when couch came back.