### PR TITLE
ensure invalid user ids still render the ticket form

### DIFF
--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -7,7 +7,7 @@
 - else
   - content = yield
 
-- if @show_navigation
+- if @show_navigation && @user
   .span2
     = render 'layouts/navigation'
   .span10

--- a/engines/support/app/views/tickets/edit.html.haml
+++ b/engines/support/app/views/tickets/edit.html.haml
@@ -1,4 +1,3 @@
-- @show_navigation = params[:user_id].present?
 - @comment = TicketComment.new
 
 .ticket

--- a/engines/support/app/views/tickets/index.html.haml
+++ b/engines/support/app/views/tickets/index.html.haml
@@ -1,5 +1,3 @@
-- @show_navigation = params[:user_id].present?
-
 = render 'tickets/tabs'
 = table @tickets, %w(subject created updated voices)
 = paginate @tickets

--- a/engines/support/app/views/tickets/new.html.haml
+++ b/engines/support/app/views/tickets/new.html.haml
@@ -1,9 +1,4 @@
-- @show_navigation = params[:user_id].present?
-
 = render 'tickets/tabs'
-
-- user = @user if admin?
-- user ||= current_user
 
 = simple_form_for @ticket, :validate => true, :html => {:class => 'form-horizontal'} do |f|
   = hidden_ticket_fields

--- a/engines/support/app/views/tickets/show.html.haml
+++ b/engines/support/app/views/tickets/show.html.haml
@@ -1,5 +1,3 @@
-- @show_navigation = params[:user_id].present?
-
 .ticket
   = render 'tickets/edit_form'
   = render 'tickets/comments'

--- a/engines/support/test/functional/tickets_controller_test.rb
+++ b/engines/support/test/functional/tickets_controller_test.rb
@@ -35,6 +35,12 @@ class TicketsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get new despite invalid user_id" do
+    get :new, user_id: :bla
+    assert_equal Ticket, assigns(:ticket).class
+    assert_response :success
+  end
+
   test "unauthenticated tickets are visible" do
     ticket = find_record :ticket, :created_by => nil
     get :show, :id => ticket.id


### PR DESCRIPTION
We still have strange urls requested like
 /pt/users/AnonymousUser.../tickets/new

Not sure where they are coming from - but this should make sure we
respond with sth. meaningful instead of erroring out.