### PR TITLE
make ticket tests pass without network connection

### DIFF
--- a/engines/support/app/models/ticket.rb
+++ b/engines/support/app/models/ticket.rb
@@ -37,9 +37,11 @@ class Ticket < CouchRest::Model::Base
 
   # email can be nil, "", or valid address.
   # validation provided by 'valid_email' gem.
+  # mx validation depends on network availability and is disabled in test
+  # and development environment
   validates :email, :allow_blank => true,
     :email => true,
-    :mx_with_fallback => true
+    :mx_with_fallback => Rails.env.production?
 
   def self.search(options = {})
     @selection = TicketSelection.new(options)

--- a/engines/support/test/unit/ticket_test.rb
+++ b/engines/support/test/unit/ticket_test.rb
@@ -8,12 +8,12 @@ class TicketTest < ActiveSupport::TestCase
 
   test "ticket with default attribs is valid" do
     t = FactoryGirl.build :ticket
-    assert t.valid?
+    assert t.valid?, t.errors.full_messages.to_sentence
   end
 
   test "ticket without email is valid" do
     t = FactoryGirl.build :ticket, email: ""
-    assert t.valid?
+    assert t.valid?, t.errors.full_messages.to_sentence
   end
 
   test "ticket validates email format" do


### PR DESCRIPTION
MX validations relied on network connection. Only using them
in production environment now. I want to be able to develop and
test when disconnected.