### PR TITLE
install: remove thin and thus eventmachine as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ group :test do
 end
 
 group :test, :development do
-  gem 'thin'
   gem 'i18n-missing_translations'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,11 +124,9 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 3, < 5)
     cucumber-wire (0.0.1)
-    daemons (1.2.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    eventmachine (1.2.0.1)
     execjs (2.6.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -276,10 +274,6 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.4)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -342,7 +336,6 @@ DEPENDENCIES
   sass-rails
   simple_form
   therubyracer
-  thin
   uglifier
   valid_email
 


### PR DESCRIPTION
They led to some install issues. No need to pick a server for dev env.