### PR TITLE
[load] require login_format_validation in session

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,3 +1,5 @@
+require 'login_format_validation'
+
 class Session < SRP::Session
   include ActiveModel::Validations
   include LoginFormatValidation


### PR DESCRIPTION
We moved it into the lib folder so it's not in an autoload path anymore.
So now it needs to be required before being used.

This fixes a load order issue that would cause non-deterministic failures
in CI